### PR TITLE
Setting ActivityEventListener requestCodes to large ints to prevent c…

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -45,8 +45,8 @@ import java.util.concurrent.Callable;
  */
 public class PickerModule extends ReactContextBaseJavaModule implements ActivityEventListener {
 
-    private static final int IMAGE_PICKER_REQUEST = 1;
-    private static final int CAMERA_PICKER_REQUEST = 2;
+    private static final int IMAGE_PICKER_REQUEST = 1062228920;
+    private static final int CAMERA_PICKER_REQUEST = 1062228921;
     private static final String E_ACTIVITY_DOES_NOT_EXIST = "E_ACTIVITY_DOES_NOT_EXIST";
 
     private static final String E_PICKER_CANCELLED_KEY = "E_PICKER_CANCELLED";


### PR DESCRIPTION
- Setting ActivityEventListener requestCodes to large ints to prevent collisions with other modules