### PR TITLE
add if (mPickerPromise == null) to croppingResult 

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -517,6 +517,10 @@ public class PickerModule extends ReactContextBaseJavaModule implements Activity
     }
 
     public void croppingResult(Activity activity, final int requestCode, final int resultCode, final Intent data) {
+        if (mPickerPromise == null) {
+            return;
+        }
+        
         if (data != null) {
             final Uri resultUri = UCrop.getOutput(data);
             if (resultUri != null) {


### PR DESCRIPTION
should check if (mPickerPromise == null) first in croppingResult  just like other result calling:imagePickerResult and cameraPickerResult. Because when app's mainActivity resumed and called onActivityResult can you get the mPickerPromise.