### PR TITLE
Allow choice of default camera (front vs. back) on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ ImagePicker.clean().then(() => {
 | maxFiles (ios only) | number (default 5) | Max number of files to select when using `multiple` option |
 | compressVideo (ios only) | bool (default true) | When video is selected, compress it and convert it to mp4 |
 | smartAlbums (ios only) | array (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from |
-
+| useFrontCamera (ios only) | bool (default false) | Whether to default to the front/'selfie' camera when opened |
 #### Response Object
 
 | Property        | Type           | Description  |
@@ -108,7 +108,7 @@ react-native link react-native-image-crop-picker
 ##### Android
 
 - [Optional] If you want to use camera picker in your project, add following to `AndroidManifest.xml`
-  - `<uses-permission android:name="android.permission.CAMERA"/>`  
+  - `<uses-permission android:name="android.permission.CAMERA"/>`
 
 #### Production build
 

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -42,7 +42,8 @@ RCT_EXPORT_MODULE();
                                 @"compressVideo": @YES,
                                 @"maxFiles": @5,
                                 @"width": @200,
-                                @"height": @200
+                                @"height": @200,
+                                @"useFrontCamera": @NO
                                 };
     }
 
@@ -106,7 +107,9 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
         picker.delegate = self;
         picker.allowsEditing = NO;
         picker.sourceType = UIImagePickerControllerSourceTypeCamera;
-        picker.delegate = self;
+        if ([[self.options objectForKey:@"useFrontCamera"] boolValue]) {
+            picker.cameraDevice = UIImagePickerControllerCameraDeviceFront;
+        }
 
         dispatch_async(dispatch_get_main_queue(), ^{
             [[self getRootVC] presentViewController:picker animated:YES completion:nil];


### PR DESCRIPTION
For easily setting an avatar picture, it is nice to be able to choose the front facing camera as the default.

This is trivial on iOS, on Android it's [a little more complicated](http://stackoverflow.com/questions/2779002/how-to-open-front-camera-on-android-platform) so implemented just for iOS for now.