### PR TITLE
onChooseButtonTouch disenable the button to avoid callbacking twice in RN. 

### DIFF
--- a/ios/RSKImageCropper/RSKImageCropper/RSKImageCropViewController.m
+++ b/ios/RSKImageCropper/RSKImageCropper/RSKImageCropViewController.m
@@ -521,6 +521,7 @@ static const CGFloat kLayoutImageScrollViewAnimationDuration = 0.25;
 
 - (void)onChooseButtonTouch:(UIBarButtonItem *)sender
 {
+    [sender setEnabled:NO];
     [self cropImage];
 }
 


### PR DESCRIPTION
which could cause a red screen issue: only one callback maybe registered to a function in a native module

![img_0499](https://cloud.githubusercontent.com/assets/8263831/21002730/3ced3098-bd62-11e6-8f05-ecbef22850e5.PNG)