### PR TITLE
fix issue #195

### DIFF
--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -535,10 +535,23 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
     return rect;
 }
 
+- (CGRect)getCropRect{
+    CGRect rect = controller.maskRect;
+    CGFloat viewWidth = CGRectGetWidth(controller.view.frame);
+    CGFloat viewHeight = CGRectGetHeight(controller.view.frame);
+    
+    if(rect.size.width > viewWidth || rect.size.height > viewHeight){
+        rect = [self scaleRect:controller];
+    }else{
+        rect = [self imageCropViewControllerCustomMaskRect:controller];
+    }
+    return rect;
+}
+
 // Returns a custom path for the mask.
 - (UIBezierPath *)imageCropViewControllerCustomMaskPath:
 (RSKImageCropViewController *)controller {
-    CGRect rect = [self scaleRect:controller];
+    CGRect rect = [self getCropRect];
     UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:rect
                                                byRoundingCorners:UIRectCornerAllCorners
                                                      cornerRadii:CGSizeMake(0, 0)];
@@ -548,7 +561,7 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
 // Returns a custom rect in which the image can be moved.
 - (CGRect)imageCropViewControllerCustomMovementRect:
 (RSKImageCropViewController *)controller {
-    return [self scaleRect:controller];
+    return [self getCropRect];
 }
 
 #pragma mark - CropFinishDelegate


### PR DESCRIPTION
If I set small width and height, croping window size seems to be incorrect.

     ImagePicker.openPicker({
          width: 100,
          height: 100,
          cropping: true
      }).then(image => {
          console.log('received image', image);
          this.setState({
              image: {uri: image.path, width: image.width, height: image.height, mime: image.mime},
              images: null
          });
      }).catch(e => {
          console.log(e);
          Alert.alert(e.message ? e.message : e);
      });

![cb31c0a775ea6cd6d0d6c079d6591e3f](https://cloud.githubusercontent.com/assets/3271333/21890892/e04607e2-d90a-11e6-8ed6-063b019fe894.jpg)

 

