### PR TITLE
iOS: Wait for crop VC dismiss before resolve

### DIFF
--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -522,14 +522,16 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
             return;
         }
 
-        self.resolve([self createAttachmentResponse:filePath
-                                          withWidth:imageResult.width
-                                         withHeight:imageResult.height
-                                           withMime:imageResult.mime
-                                           withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
-                                           withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]]);
-
-        [viewController dismissViewControllerAnimated:YES completion:nil];
+        // Wait for viewController to dismiss before resolving, or we lose the ability to display
+        // Alert.alert in the .then() handler.
+        __weak __typeof__(self) weakSelf = self;
+        [viewController dismissViewControllerAnimated:YES completion:^{
+            weakSelf.resolve([weakSelf createAttachmentResponse:filePath
+                                              withWidth:imageResult.width
+                                             withHeight:imageResult.height
+                                               withMime:imageResult.mime
+                                               withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
+                                               withData:[[weakSelf.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]]);
     }
 }
 


### PR DESCRIPTION
Allows ImagePicker.openCamera().then() handler to perform Alert.alert.

Test case:

```objc
ImagePicker.openCamera({
    compressImageMaxWidth: 1024,
    compressImageMaxHeight: 1024,
    compressImageQuality: 0.7,
  })
    .then((image) => {
      Alert.alert('Picture taken')
    });
```

In existing codebase
--
- The Alert is not displayed.  Repeat with a Chrome breakpoint on the Alert line - wait a few seconds, then continue = Alert displayed. Demonstrates this is a timing issue

With this PR
----

- the alert is displayed every time, regardless of whether there's a breakpoint or not.

