### PR TITLE
iOS: Wait for viewController to dismiss before resolving or rejecting

### DIFF
--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -604,7 +604,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     }];
 }
 
-- (void) dismissCropper:(RSKImageCropViewController*) controller completion:(^void) completion{
+- (void) dismissCropper:(RSKImageCropViewController*) controller completion:(void (^)())completion {
     //We've presented the cropper on top of the image picker as to not have a double modal animation.
     //Thus, we need to dismiss the image picker view controller to dismiss the whole stack.
     if (!self.cropOnly) {

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -141,8 +141,9 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
-    self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
-    [picker dismissViewControllerAnimated:YES completion:NULL];
+    [picker dismissViewControllerAnimated:YES completion:^{
+        self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
+    }];
 }
 
 - (NSString*) getTmpDirectory {
@@ -598,8 +599,9 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 // Crop image has been canceled.
 - (void)imageCropViewControllerDidCancelCrop:
 (RSKImageCropViewController *)controller {
-    self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
-    [self dismissCropper:controller];
+    [self dismissCropper:controller completion:^{
+        self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
+    }];
 }
 
 - (void) dismissCropper:(RSKImageCropViewController*) controller completion:(^void) completion{

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -521,15 +521,18 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
             [viewController dismissViewControllerAnimated:YES completion:nil];
             return;
         }
-
-        self.resolve([self createAttachmentResponse:filePath
-                                          withWidth:imageResult.width
-                                         withHeight:imageResult.height
-                                           withMime:imageResult.mime
-                                           withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
-                                           withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]]);
-
-        [viewController dismissViewControllerAnimated:YES completion:nil];
+        
+        // Wait for viewController to dismiss before resolving, or we lose the ability to display
+        // Alert.alert in the .then() handler.
+        __weak __typeof__(self) weakSelf = self;
+        [viewController dismissViewControllerAnimated:YES completion:^{
+            weakSelf.resolve([weakSelf createAttachmentResponse:filePath
+                                                      withWidth:imageResult.width
+                                                     withHeight:imageResult.height
+                                                       withMime:imageResult.mime
+                                                       withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
+                                                       withData:[[weakSelf.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]]);
+        }];
     }
 }
 

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -396,10 +396,11 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                             [lock lock];
                             
                             if (video == nil) {
-                                self.reject(ERROR_CANNOT_PROCESS_VIDEO_KEY, ERROR_CANNOT_PROCESS_VIDEO_MSG, nil);
                                 [indicatorView stopAnimating];
                                 [overlayView removeFromSuperview];
-                                [imagePickerController dismissViewControllerAnimated:YES completion:nil];
+                                [imagePickerController dismissViewControllerAnimated:YES completion:^{
+                                    self.reject(ERROR_CANNOT_PROCESS_VIDEO_KEY, ERROR_CANNOT_PROCESS_VIDEO_MSG, nil);
+                                }];
                                 return;
                             }
                             
@@ -408,10 +409,11 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                             [lock unlock];
 
                             if (processed == [assets count]) {
-                                self.resolve(selections);
                                 [indicatorView stopAnimating];
                                 [overlayView removeFromSuperview];
-                                [imagePickerController dismissViewControllerAnimated:YES completion:nil];
+                                [imagePickerController dismissViewControllerAnimated:YES completion:^{
+                                    self.resolve(selections);
+                                }];
                                 return;
                             }
                         });
@@ -429,10 +431,11 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                              NSString *filePath = [self persistFile:imageResult.data];
                              
                              if (filePath == nil) {
-                                 self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
                                  [indicatorView stopAnimating];
                                  [overlayView removeFromSuperview];
-                                 [imagePickerController dismissViewControllerAnimated:YES completion:nil];
+                                 [imagePickerController dismissViewControllerAnimated:YES completion:^{
+                                     self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
+                                 }];
                                  return;
                              }
 
@@ -447,10 +450,12 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                              [lock unlock];
 
                              if (processed == [assets count]) {
-                                 self.resolve(selections);
+
                                  [indicatorView stopAnimating];
                                  [overlayView removeFromSuperview];
-                                 [imagePickerController dismissViewControllerAnimated:YES completion:nil];
+                                 [imagePickerController dismissViewControllerAnimated:YES completion:^{
+                                     self.resolve(selections);
+                                 }];
                                  return;
                              }
                          });
@@ -465,16 +470,15 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
             if (phAsset.mediaType == PHAssetMediaTypeVideo) {
                 [self getVideoAsset:phAsset completion:^(NSDictionary* video) {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        if (video != nil) {
-                            self.resolve(video);
-                        } else {
-                            self.reject(ERROR_CANNOT_PROCESS_VIDEO_KEY, ERROR_CANNOT_PROCESS_VIDEO_MSG, nil);
-                        }
-
-
                         [indicatorView stopAnimating];
                         [overlayView removeFromSuperview];
-                        [imagePickerController dismissViewControllerAnimated:YES completion:nil];
+                        [imagePickerController dismissViewControllerAnimated:YES completion:^{
+                            if (video != nil) {
+                                self.resolve(video);
+                            } else {
+                                self.reject(ERROR_CANNOT_PROCESS_VIDEO_KEY, ERROR_CANNOT_PROCESS_VIDEO_MSG, nil);
+                            }
+                        }];
                     });
                 }];
             } else {
@@ -496,8 +500,9 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 }
 
 - (void)qb_imagePickerControllerDidCancel:(QBImagePickerController *)imagePickerController {
-    self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
-    [imagePickerController dismissViewControllerAnimated:YES completion:nil];
+    [imagePickerController dismissViewControllerAnimated:YES completion:^{
+        self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
+    }];
 }
 
 // when user selected single image, with camera or from photo gallery,
@@ -506,8 +511,9 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 - (void) processSingleImagePick:(UIImage*)image withViewController:(UIViewController*)viewController {
 
     if (image == nil) {
-        self.reject(ERROR_PICKER_NO_DATA_KEY, ERROR_PICKER_NO_DATA_MSG, nil);
-        [viewController dismissViewControllerAnimated:YES completion:nil];
+        [viewController dismissViewControllerAnimated:YES completion:^{
+            self.reject(ERROR_PICKER_NO_DATA_KEY, ERROR_PICKER_NO_DATA_MSG, nil);
+        }];
         return;
     }
 
@@ -517,21 +523,21 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         ImageResult *imageResult = [self.compression compressImage:image withOptions:self.options];
         NSString *filePath = [self persistFile:imageResult.data];
         if (filePath == nil) {
-            self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
-            [viewController dismissViewControllerAnimated:YES completion:nil];
+            [viewController dismissViewControllerAnimated:YES completion:^{
+                self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
+            }];
             return;
         }
         
         // Wait for viewController to dismiss before resolving, or we lose the ability to display
         // Alert.alert in the .then() handler.
-        __weak __typeof__(self) weakSelf = self;
         [viewController dismissViewControllerAnimated:YES completion:^{
-            weakSelf.resolve([weakSelf createAttachmentResponse:filePath
+            self.resolve([self createAttachmentResponse:filePath
                                                       withWidth:imageResult.width
                                                      withHeight:imageResult.height
                                                        withMime:imageResult.mime
                                                        withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
-                                                       withData:[[weakSelf.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]]);
+                                                       withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]]);
         }];
     }
 }
@@ -596,14 +602,14 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     [self dismissCropper:controller];
 }
 
-- (void) dismissCropper:(RSKImageCropViewController*) controller {
+- (void) dismissCropper:(RSKImageCropViewController*) controller completion:(^void) completion{
     //We've presented the cropper on top of the image picker as to not have a double modal animation.
     //Thus, we need to dismiss the image picker view controller to dismiss the whole stack.
     if (!self.cropOnly) {
         UIViewController *topViewController = controller.presentingViewController.presentingViewController;
-        [topViewController dismissViewControllerAnimated:YES completion:nil];
+        [topViewController dismissViewControllerAnimated:YES completion:completion];
     } else {
-        [controller dismissViewControllerAnimated:YES completion:nil];
+        [controller dismissViewControllerAnimated:YES completion:completion];
     }
 }
 
@@ -620,19 +626,20 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 
     NSString *filePath = [self persistFile:imageResult.data];
     if (filePath == nil) {
-        self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
-        [self dismissCropper:controller];
+        [self dismissCropper:controller completion:^{
+            self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
+        }];
         return;
     }
 
-    self.resolve([self createAttachmentResponse:filePath
-                                      withWidth:imageResult.width
-                                     withHeight:imageResult.height
-                                       withMime:imageResult.mime
-                                       withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
-                                       withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]]);
-
-    [self dismissCropper:controller];
+    [self dismissCropper:controller completion:^{
+        self.resolve([self createAttachmentResponse:filePath
+                                          withWidth:imageResult.width
+                                         withHeight:imageResult.height
+                                           withMime:imageResult.mime
+                                           withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
+                                           withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]]);
+    }];
 }
 
 // at the moment it is not possible to upload image by reading PHAsset


### PR DESCRIPTION
Allows ImagePicker.openCamera().then() handler to perform Alert.alert.

Test case:

```objc
import {Alert} from 'react-native';

ImagePicker.openCamera({
    compressImageMaxWidth: 1024,
    compressImageMaxHeight: 1024,
    compressImageQuality: 0.7,
  })
    .then((image) => {
      Alert.alert('Picture taken')
    });
```

In existing codebase
--
- The Alert is not displayed.  Repeat with a Chrome breakpoint on the Alert line - wait a few seconds, then continue = Alert displayed. Demonstrates this is a timing issue

With this PR
----

- the alert is displayed every time, regardless of whether there's a breakpoint or not.

The same logic has been applied to each .reject() too.


Tested via Xcode 8.2.1, React Native 0.41.2 on iPhone 6 running iOS 10.2