### PR TITLE
Add possibility to hide crop guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ ImagePicker.clean().then(() => {
 | loadingLabelText (ios only) | string (default "Processing assets...") | Text displayed while photo is loading in picker |
 | mediaType | string (default any) | Accepted mediaType for image selection, can be one of: 'photo', 'video', or 'any' |
 | showsSelectedCount (ios only) | bool (default true) | Whether to show the number of selected assets |
+| showCropGuidelines (android only) | bool (default true) | Whether to show the 3x3 grid on top of the image during cropping |
 #### Response Object
 
 | Property        | Type           | Description  |

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -67,6 +67,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     private boolean includeBase64 = false;
     private boolean cropping = false;
     private boolean cropperCircleOverlay = false;
+    private boolean showCropGuidelines = true;
     private ReadableMap options;
 
 
@@ -110,6 +111,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         cropping = options.hasKey("cropping") ? options.getBoolean("cropping") : cropping;
         cropperTintColor = options.hasKey("cropperTintColor") ? options.getString("cropperTintColor") : cropperTintColor;
         cropperCircleOverlay = options.hasKey("cropperCircleOverlay") ? options.getBoolean("cropperCircleOverlay") : cropperCircleOverlay;
+        showCropGuidelines = options.hasKey("showCropGuidelines") ? options.getBoolean("showCropGuidelines") : showCropGuidelines;
         this.options = options;
     }
 
@@ -551,6 +553,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         options.setCompressionFormat(Bitmap.CompressFormat.JPEG);
         options.setCompressionQuality(100);
         options.setCircleDimmedLayer(cropperCircleOverlay);
+        options.setShowCropGrid(showCropGuidelines);
         configureCropperColors(options);
 
         UCrop.of(uri, Uri.fromFile(new File(this.getTmpDir(activity), UUID.randomUUID().toString() + ".jpg")))


### PR DESCRIPTION
Possibility to hide the default 3x3 -grid on the image during cropping.

```
ImagePicker.openCropper({
      ...
      showCropGuidelines: false
});
```