### PR TITLE
#283 Create DIRECTORY_PICTURES if it doesn't exist

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -683,14 +683,21 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private File createImageFile() throws IOException {
+
         String imageFileName = "image-" + UUID.randomUUID().toString();
         File path = Environment.getExternalStoragePublicDirectory(
                 Environment.DIRECTORY_PICTURES);
+
+        if (!path.exists() && !path.isDirectory()) {
+            path.mkdirs();
+        }
+
         File image = File.createTempFile(imageFileName, ".jpg", path);
 
         // Save a file: path for use with ACTION_VIEW intents
         mCurrentPhotoPath = "file:" + image.getAbsolutePath();
 
         return image;
+
     }
 }


### PR DESCRIPTION
According to [official docs example](https://developer.android.com/reference/android/os/Environment.html#getExternalStoragePublicDirectory(java.lang.String)), you need to make sure that the external storage directory you want to manipulate (`Environment.DIRECTORY_PICTURES`, in this case) exists.

When running the previous code in Android 4.4 (KitKat), the method `PickerModule#createImageFile()`  throws an IOException, because there was no existing directory when calling `File#createTempFile()`. This behavior was documented in the issue #283.

So, I've just called `path.mkdirs()` to create the directory, inside an `if` statement that checks if the folder doesn't exist (which is not necessary, but make things more clear, though).