### PR TITLE
Update HEADER_SEARCH_PATHS to be more compatible

### DIFF
--- a/ios/imageCropPicker.xcodeproj/project.pbxproj
+++ b/ios/imageCropPicker.xcodeproj/project.pbxproj
@@ -302,8 +302,8 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/RSKImageCropper/build/Debug-iphoneos";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../example/node_modules/react-native/React/**",
-					"$(SRCROOT)/../example/node_modules/react-native/Libraries/Image/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../react-native/Libraries/Image/**",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = NO;
@@ -323,8 +323,8 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/RSKImageCropper/build/Debug-iphoneos";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../example/node_modules/react-native/React/**",
-					"$(SRCROOT)/../example/node_modules/react-native/Libraries/Image/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../react-native/Libraries/Image/**",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
Referencing #287, the previous header search paths reference the React Native version from the example project, as opposed to that of the actual source project that the lib is included from. It was causing errors if there was inconsistency between the example and the actual project.
