### PR TITLE
Add podspec

### DIFF
--- a/ios/ImageCropPicker.h
+++ b/ios/ImageCropPicker.h
@@ -18,8 +18,14 @@
 #import <React/RCTImageLoader.h>
 #endif
 
+#if __has_include("QBImagePicker.h")
+#import "QBImagePicker.h"
+#import "RSKImageCropper.h"
+#else
 #import "QBImagePicker/QBImagePicker.h"
 #import "RSKImageCropper/RSKImageCropper.h"
+#endif
+
 #import "UIImage-Resize/UIImage+Resize.h"
 #import "Compression.h"
 #import <math.h>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-crop-picker",
-  "version": "0.12.10",
+  "version": "0.13.0",
   "description": "Select single or multiple images, with croping option",
   "main": "index.js",
   "scripts": {

--- a/react-native-image-crop-picker.podspec
+++ b/react-native-image-crop-picker.podspec
@@ -1,0 +1,18 @@
+require "json"
+package = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name          = package['name']
+  s.version       = package['version']
+  s.summary       = package['description']
+  s.author        = "Ivan Pusic"
+  s.license       = package['license']
+  s.requires_arc  = true
+  s.homepage      = "https://github.com/ivpusic/react-native-image-crop-picker"
+  s.source        = { :git => 'https://github.com/ivpusic/react-native-image-crop-picker.git' }
+  s.platform      = :ios, '8.0'
+  s.source_files  = "ios/*.{h,m}", "ios/UIImage-Resize/*.{h,m}"
+
+  s.dependency "QBImagePickerController"
+  s.dependency "RSKImageCropper"
+end


### PR DESCRIPTION
FYI @ivpusic. I'll leave the documentation updates to you.

Fixes #307 

Now you simply add this to your `Podfile` with no reference to any other dependency and run your app:
```
pod 'react-native-image-crop-picker', path: 'node_modules/react-native-image-crop-picker'
``` 

Note: I put my `Podfile` in the app root (not `[root]/ios`) so the path would change if you used default pattern of sticking it in `[root]/ios`.
```
pod 'react-native-image-crop-picker', path: '../node_modules/react-native-image-crop-picker'
``` 