### PR TITLE
Fix getMimeType on Android. It's wrong if the name has space.

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -17,7 +17,6 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.FileProvider;
 import android.util.Base64;
 import android.webkit.MimeTypeMap;
-import android.util.Log;
 import android.content.ContentResolver;
 
 import com.facebook.react.bridge.ActivityEventListener;


### PR DESCRIPTION
If the name has space or doesn't include the extension, `getMimeType` will return null. 