### PR TITLE
Removed TeamID from XCode-project-file.

### DIFF
--- a/ios/QBImagePicker/QBImagePicker.xcodeproj/project.pbxproj
+++ b/ios/QBImagePicker/QBImagePicker.xcodeproj/project.pbxproj
@@ -215,7 +215,6 @@
 				TargetAttributes = {
 					340A78CB1D7909FB00241672 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 5WFBC66J2G;
 					};
 					AAA8FE021ACDA079002A9710 = {
 						CreatedOnToolsVersion = 6.2;

--- a/ios/RSKImageCropper/RSKImageCropper.xcodeproj/project.pbxproj
+++ b/ios/RSKImageCropper/RSKImageCropper.xcodeproj/project.pbxproj
@@ -172,7 +172,6 @@
 				TargetAttributes = {
 					340A78C61D79092200241672 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 5WFBC66J2G;
 					};
 					A5BE393C1B32B49D00ECDF88 = {
 						CreatedOnToolsVersion = 6.3.2;


### PR DESCRIPTION
This PR removes your TeamID out of the XCode-Projectfiles. When the TeamID is included, XCode 
does it not allow to create an Archive unless the current developer is member of your team.

The issue that will be fixed here is:

> No "iOS Development" signing certificate matching team ID "5WFBC66J2G" with a private key was found.

More information about this issue you can find here: https://github.com/ruslanskorb/RSKImageCropper/issues/164

It does not break any compatibility.