### PR TITLE
Fix RSKImageCropper not found

### DIFF
--- a/ios/ImageCropPicker.h
+++ b/ios/ImageCropPicker.h
@@ -23,7 +23,7 @@
 #import "RSKImageCropper.h"
 #else
 #import "QBImagePicker/QBImagePicker.h"
-#import "RSKImageCropper/RSKImageCropper.h"
+#import <RSKImageCropper/RSKImageCropper.h>
 #endif
 
 #import "UIImage-Resize/UIImage+Resize.h"


### PR DESCRIPTION
When I try to compile my app in release I got a compilation error with this line:

```
#import "RSKImageCropper/RSKImageCropper.h"
```

I try everything, clean the cache, remove pod dependencies and reinstall, unlink an link again, but nothing works, the only solution I found is to change the import to this:

```
#import <RSKImageCropper/RSKImageCropper.h>
```

Doesn't seems to be a big difference, but it's now working for me