### PR TITLE
[iOS] Fix  a bug that cause a {0,0} size image

### DIFF
--- a/ios/Compression.m
+++ b/ios/Compression.m
@@ -34,8 +34,11 @@
     NSNumber *maxWidth = [options valueForKey:@"compressImageMaxWidth"];
     NSNumber *maxHeight = [options valueForKey:@"compressImageMaxHeight"];
     ImageResult *result = [[ImageResult alloc] init];
-    
-    if ([maxWidth integerValue] == 0 || [maxWidth integerValue] == 0) {
+                                
+    //[origin] if ([maxWidth integerValue] == 0 || [maxHeight integerValue] == 0) {
+    //when pick a width< height image and only set "compressImageMaxWidth",will cause a {0,0}size image
+    //Now fix it                       
+    if ([maxWidth integerValue] == 0 || [maxHeight integerValue] == 0) {
         result.width = [NSNumber numberWithFloat:image.size.width];
         result.height = [NSNumber numberWithFloat:image.size.height];
         result.image = image;


### PR DESCRIPTION
-[origin] if ([maxWidth integerValue] == 0 || [maxHeight integerValue] == 0) {
-When pick a width< height image and only set "compressImageMaxWidth",will cause  {0,0}size image.
-Now i fix it.