### PR TITLE
Fix for adding files more than 30 at once for iOS

### DIFF
--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -451,28 +451,30 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 
                          dispatch_async(dispatch_get_main_queue(), ^{
                              [lock lock];
-                             UIImage *imgT = [UIImage imageWithData:imageData];
-                             UIImage *imageT = [imgT fixOrientation];
-
-                             ImageResult *imageResult = [self.compression compressImage:imageT withOptions:self.options];
-                             NSString *filePath = [self persistFile:imageResult.data];
-
-                             if (filePath == nil) {
-                                 [indicatorView stopAnimating];
-                                 [overlayView removeFromSuperview];
-                                 [imagePickerController dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
-                                     self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
-                                 }]];
-                                 return;
+                             @autoreleasepool {
+                                 UIImage *imgT = [UIImage imageWithData:imageData];
+                                 UIImage *imageT = [imgT fixOrientation];
+                                 
+                                 ImageResult *imageResult = [self.compression compressImage:imageT withOptions:self.options];
+                                 NSString *filePath = [self persistFile:imageResult.data];
+                                 
+                                 if (filePath == nil) {
+                                     [indicatorView stopAnimating];
+                                     [overlayView removeFromSuperview];
+                                     [imagePickerController dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
+                                         self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
+                                     }]];
+                                     return;
+                                 }
+                                 
+                                 [selections addObject:[self createAttachmentResponse:filePath
+                                                                            withWidth:imageResult.width
+                                                                           withHeight:imageResult.height
+                                                                             withMime:imageResult.mime
+                                                                             withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
+                                                                             withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]
+                                                        ]];
                              }
-
-                             [selections addObject:[self createAttachmentResponse:filePath
-                                                                        withWidth:imageResult.width
-                                                                       withHeight:imageResult.height
-                                                                         withMime:imageResult.mime
-                                                                         withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
-                                                                         withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : [NSNull null]
-                                                    ]];
                              processed++;
                              [lock unlock];
 


### PR DESCRIPTION
I have getting crashes with selecting >30 images at once some times on iOS. I noticed that the less free memory you have, the more chance to get the crash you have.