### PR TITLE
Fix crash when taking photo from camera on ios

### DIFF
--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -579,8 +579,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         // Alert.alert in the .then() handler.
         [viewController dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
             self.resolve([self createAttachmentResponse:filePath
-                                              withLocalIdentifier: localIdentifier
-                                              withFilename: filename
+                                    withLocalIdentifier:(localIdentifier) ? localIdentifier : @""
+                                           withFilename:(filename) ? filename : @""
                                               withWidth:imageResult.width
                                              withHeight:imageResult.height
                                                withMime:imageResult.mime


### PR DESCRIPTION
Dictionary was being initialized with nil values which causes crash in Obj-C. I've put a ternary in that will send empty string values for the possible nil values