### PR TITLE
Add podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ react-native link react-native-image-crop-picker
 
 ###### Cocoapods
 
+Add this line to your Podfile and run `pod install`
 ```
 pod 'react-native-image-crop-picker', :path => '../node_modules/react-native-image-crop-picker'
-
 ```
 
 #### Post-install steps

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ ImagePicker.clean().then(() => {
 
 ## Install
 
-### Install node package
+### Install package
 
 ```
 npm i react-native-image-crop-picker --save

--- a/README.md
+++ b/README.md
@@ -113,9 +113,26 @@ ImagePicker.clean().then(() => {
 
 ## Install
 
+### Install node package
+
 ```
 npm i react-native-image-crop-picker --save
+```
+
+You can link the package using react-native link or cocoapods.
+
+
+###### Manual
+
+```
 react-native link react-native-image-crop-picker
+```
+
+###### Cocoapods
+
+```
+pod 'react-native-image-crop-picker', :path => '../node_modules/react-native-image-crop-picker'
+
 ```
 
 #### Post-install steps
@@ -124,12 +141,11 @@ react-native link react-native-image-crop-picker
 
 In Xcode open Info.plist and add string key `NSPhotoLibraryUsageDescription` with value that describes why do you need access to user photos. More info here https://forums.developer.apple.com/thread/62229. Depending on what features you use, you also may need `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` keys.
 
-###### cocoapods users
+###### Cocoapods
 
-- Add `platform :ios, '8.0'` to Podfile (!important)
-- Add `pod 'RSKImageCropper'` and `pod 'QBImagePickerController'` to Podfile
+You are done.
 
-###### non-cocoapods users
+###### Manual
 
 - Drag and drop the ios/ImageCropPickerSDK folder to your xcode project. (Make sure Copy items if needed IS ticked)
 - Click on project General tab

--- a/ios/ImageCropPicker.h
+++ b/ios/ImageCropPicker.h
@@ -21,8 +21,11 @@
 #if __has_include("QBImagePicker.h")
 #import "QBImagePicker.h"
 #import "RSKImageCropper.h"
-#else
+#elseif __has_include("QBImagePicker/QBImagePicker.h")
 #import "QBImagePicker/QBImagePicker.h"
+#import <RSKImageCropper/RSKImageCropper.h>
+#else
+#import "QBImagePickerController/QBImagePickerController.h"
 #import <RSKImageCropper/RSKImageCropper.h>
 #endif
 

--- a/react-native-image-crop-picker.podspec
+++ b/react-native-image-crop-picker.podspec
@@ -1,0 +1,18 @@
+require "json"
+package = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name          = package['name']
+  s.version       = package['version']
+  s.summary       = package['description']
+  s.author        = "Ivan Pusic"
+  s.license       = package['license']
+  s.requires_arc  = true
+  s.homepage      = "https://github.com/ivpusic/react-native-image-crop-picker"
+  s.source        = { :git => 'https://github.com/ivpusic/react-native-image-crop-picker.git' }
+  s.platform      = :ios, '8.0'
+  s.source_files  = "ios/*.{h,m}", "ios/UIImage-Resize/*.{h,m}"
+
+  s.dependency "QBImagePickerController"
+  s.dependency "RSKImageCropper"
+end


### PR DESCRIPTION
Using [#372](https://github.com/ivpusic/react-native-image-crop-picker/pull/372) as reference creating this PR. This PR fixes an issue in the ImageCropPicker.h where it will fail to compile if linked manually.