### PR TITLE
Support header file resolution

### DIFF
--- a/ios/ImageCropPicker.h
+++ b/ios/ImageCropPicker.h
@@ -18,11 +18,15 @@
 #import <React/RCTImageLoader.h>
 #endif
 
+
 #if __has_include("QBImagePicker.h")
 #import "QBImagePicker.h"
 #import "RSKImageCropper.h"
-#else
+#elif __has_include("QBImagePicker/QBImagePicker.h")
 #import "QBImagePicker/QBImagePicker.h"
+#import <RSKImageCropper/RSKImageCropper.h>
+#else
+#import "QBImagePickerController/QBImagePickerController.h"
 #import <RSKImageCropper/RSKImageCropper.h>
 #endif
 

--- a/react-native-image-crop-picker.podspec
+++ b/react-native-image-crop-picker.podspec
@@ -1,0 +1,18 @@
+require "json"
+package = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name          = package['name']
+  s.version       = package['version']
+  s.summary       = package['description']
+  s.author        = "Ivan Pusic"
+  s.license       = package['license']
+  s.requires_arc  = true
+  s.homepage      = "https://github.com/ivpusic/react-native-image-crop-picker"
+  s.source        = { :git => 'https://github.com/ivpusic/react-native-image-crop-picker.git' }
+  s.platform      = :ios, '8.0'
+  s.source_files  = "ios/*.{h,m}", "ios/UIImage-Resize/*.{h,m}"
+
+  s.dependency "QBImagePickerController"
+  s.dependency "RSKImageCropper"
+end


### PR DESCRIPTION
Added a podspec but not mentioning it in the README. Developers who use cocoapods for depedency management will look for a podspec file and use. 

`#elseif` is not working as expected. `#elif` seems to work so using it instead.