### PR TITLE
Added video docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ ImagePicker.openPicker({
 });
 ```
 
+Select video only from gallery
+```javascript
+ImagePicker.openPicker({
+  mediaType: "video",
+}).then((video) => {
+  console.log(video);
+});
+```
+
+**Android: The prop 'cropping' has been known to cause videos not to be display in the gallery on Android. Please do not set cropping to true when selecting videos.** 
+
+
 ### Select from camera
 ```javascript
 ImagePicker.openCamera({


### PR DESCRIPTION
Added additional example to the code snippets provided, showing how to select videos with the ImagePicker. 

Also documented the behaviour whereby having the prop 'cropping' set to true results in no videos being shown on Android. I have stated that this issue is known to have happened, rather than stating that it happens all the time, due to the relative poor test coverage across the broad spectrum of Android devices available.