### PR TITLE
Adds podspec for installation via cocoapods

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,8 +14,14 @@ android {
     }
 }
 
+repositories {
+    maven {
+        url "$rootDir/../node_modules/react-native/android"
+    }
+}
+
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:0.48.1'
     compile 'com.yalantis:ucrop:2.2.0-native'
     compile 'id.zelory:compressor:2.1.0'
 }

--- a/ios/Compression.m
+++ b/ios/Compression.m
@@ -73,9 +73,9 @@
     if (compressQuality == nil) {
         compressQuality = [NSNumber numberWithFloat:1];
     }
-    
-    result.data = UIImageJPEGRepresentation(result.image, [compressQuality floatValue]);
-    result.mime = @"image/jpeg";
+
+    result.data = UIImagePNGRepresentation(result.image);
+    result.mime = @"image/png";
     
     return result;
 }

--- a/ios/ImageCropPicker.h
+++ b/ios/ImageCropPicker.h
@@ -22,7 +22,7 @@
 #import "QBImagePicker.h"
 #import "RSKImageCropper.h"
 #else
-#import "QBImagePicker/QBImagePicker.h"
+#import <QBImagePickerController/QBImagePickerController.h>
 #import <RSKImageCropper/RSKImageCropper.h>
 #endif
 

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -684,7 +684,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     // we have correct rect, but not correct dimensions
     // so resize image
     CGSize resizedImageSize = CGSizeMake([[[self options] objectForKey:@"width"] intValue], [[[self options] objectForKey:@"height"] intValue]);
-    UIImage *resizedImage = [croppedImage resizedImageToFitInSize:resizedImageSize scaleIfSmaller:YES];
+    UIImage *resizedImage = [ImageCropPicker circularScaleAndCropImage:croppedImage
+                                                                 frame:CGRectMake(0, 0, resizedImageSize.width, resizedImageSize.height)];
     ImageResult *imageResult = [self.compression compressImage:resizedImage withOptions:self.options];
 
     NSString *filePath = [self persistFile:imageResult.data];
@@ -714,7 +715,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     // create temp file
     NSString *tmpDirFullPath = [self getTmpDirectory];
     NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
-    filePath = [filePath stringByAppendingString:@".jpg"];
+    filePath = [filePath stringByAppendingString:@".png"];
 
     // save cropped file
     BOOL status = [data writeToFile:filePath atomically:YES];
@@ -732,6 +733,51 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                   usingCropRect:(CGRect)cropRect
                   rotationAngle:(CGFloat)rotationAngle {
     [self imageCropViewController:controller didCropImage:croppedImage usingCropRect:cropRect];
+}
+
++ (UIImage*)circularScaleAndCropImage:(UIImage*)image frame:(CGRect)frame {
+    // This function returns a newImage, based on image, that has been:
+    // - scaled to fit in (CGRect) rect
+    // - and cropped within a circle of radius: rectWidth/2
+
+    //Create the bitmap graphics context
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(frame.size.width, frame.size.height), NO, 0.0);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+
+    //Get the width and heights
+    CGFloat imageWidth = image.size.width;
+    CGFloat imageHeight = image.size.height;
+    CGFloat rectWidth = frame.size.width;
+    CGFloat rectHeight = frame.size.height;
+
+    //Calculate the scale factor
+    CGFloat scaleFactorX = rectWidth/imageWidth;
+    CGFloat scaleFactorY = rectHeight/imageHeight;
+
+    //Calculate the centre of the circle
+    CGFloat imageCentreX = rectWidth/2;
+    CGFloat imageCentreY = rectHeight/2;
+
+    // Create and CLIP to a CIRCULAR Path
+    // (This could be replaced with any closed path if you want a different shaped clip)
+    CGFloat radius = rectWidth/2;
+    CGContextBeginPath (context);
+    CGContextAddArc (context, imageCentreX, imageCentreY, radius, 0, 2*M_PI, 0);
+    CGContextClosePath (context);
+    CGContextClip (context);
+
+    //Set the SCALE factor for the graphics context
+    //All future draw calls will be scaled by this factor
+    CGContextScaleCTM (context, scaleFactorX, scaleFactorY);
+
+    // Draw the IMAGE
+    CGRect myRect = CGRectMake(0, 0, imageWidth, imageHeight);
+    [image drawInRect:myRect];
+
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    return newImage;
 }
 
 @end

--- a/ios/ImageCropPicker.podspec
+++ b/ios/ImageCropPicker.podspec
@@ -1,0 +1,22 @@
+require 'json'
+version = JSON.parse(File.read('../package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+    s.name            = "ImageCropPicker"
+    s.version         = version
+    s.homepage        = "https://github.com/ivpusic/react-native-image-crop-picker"
+    s.summary         = "iOS/Android image picker with support for camera, configurable compression, multiple images and cropping"
+    s.license         = "MIT"
+    s.author          = { "Ivan Pusic" => "pusic007@gmail.com" }
+    s.ios.deployment_target = '8.0'
+    s.source          = { :git => "https://github.com/ivpusic/react-native-image-crop-picker.git", :tag => "#{s.version}" }
+    s.source_files    = '*.{h,m}'
+    s.preserve_paths  = "**/*.js"
+
+    s.dependency 'React'
+    s.dependency 'RSKImageCropper', '1.6.3'
+    s.dependency 'QBImagePickerController', '3.4.0'
+    s.dependency 'UIImage-Resize', '1.0.1'
+
+  end


### PR DESCRIPTION
Fixes issue where `NativeModules.ImageCropPicker` (default export) would be undefined when installing with cocoapods. Possibly related to #431.

All this does is add a podspec for the iOS native module that you can reference from the rn app's `ios/Podfile`. Needed to change an import to make it work.

To install you should run

```
npm i react-native-image-crop-picker --save
```

and then in your `ios/Podfile` add:

```ruby
pod 'ImageCropPicker', :path => '../node_modules/react-native-image-crop-picker/ios'
```

The above should also go in the README.md.