### PR TITLE
Update index.d.ts to mute the error message

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,4 +38,12 @@ declare module "react-native-image-crop-picker" {
     export function openCropper(options: Options): Promise<Image>;
     export function clean(): Promise<void>;
     export function cleanSingle(path: string): Promise<void>;
+
+    export default {
+        openPicker,
+        openCamera,
+        openCropper,
+        clean,
+        cleanSingle
+    }
 }


### PR DESCRIPTION
Try to mute the warning of "[ts] Module react-native-image-corp-picker has no default export"

After careful consideration, I have not increased the typescript example in the readme file, because the code of typescript and javascript are almost the same.

Really appreciate all your kind help.