### PR TITLE
[Fix] iOS: Remove *.h files from Compile Sources

### DIFF
--- a/ios/imageCropPicker.xcodeproj/project.pbxproj
+++ b/ios/imageCropPicker.xcodeproj/project.pbxproj
@@ -9,8 +9,6 @@
 /* Begin PBXBuildFile section */
 		3400A8161CEB54F3008A0BC7 /* ImageCropPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 3400A8151CEB54F3008A0BC7 /* ImageCropPicker.m */; };
 		3408F5F11E0DE76F00E97159 /* Compression.m in Sources */ = {isa = PBXBuildFile; fileRef = 3408F5F01E0DE76F00E97159 /* Compression.m */; };
-		347CE16F1D6BB134002A8704 /* ImageCropPicker.h in Sources */ = {isa = PBXBuildFile; fileRef = 3400A8141CEB54F3008A0BC7 /* ImageCropPicker.h */; };
-		347CE1701D6BB134002A8704 /* UIImage+Resize.h in Sources */ = {isa = PBXBuildFile; fileRef = 34963A931D6B919800F9CA2F /* UIImage+Resize.h */; };
 		34963AB11D6B96A800F9CA2F /* UIImage+Resize.m in Sources */ = {isa = PBXBuildFile; fileRef = 34963A941D6B919800F9CA2F /* UIImage+Resize.m */; };
 		34EC4AB51D78FEC6001E9E86 /* QBImagePicker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34434E2E1D6F5EA300BF5063 /* QBImagePicker.framework */; };
 		34EC4AB61D78FEC6001E9E86 /* RSKImageCropper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34434E3A1D6F5EBB00BF5063 /* RSKImageCropper.framework */; };
@@ -203,8 +201,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3408F5F11E0DE76F00E97159 /* Compression.m in Sources */,
-				347CE16F1D6BB134002A8704 /* ImageCropPicker.h in Sources */,
-				347CE1701D6BB134002A8704 /* UIImage+Resize.h in Sources */,
 				34963AB11D6B96A800F9CA2F /* UIImage+Resize.m in Sources */,
 				3400A8161CEB54F3008A0BC7 /* ImageCropPicker.m in Sources */,
 			);


### PR DESCRIPTION
Hey!

Warning

```
[07:47:52]: no rule to process file '...../react-native-image-crop-picker/ios/ImageCropPicker.h' of type sourcecode.c.h for architecture arm64
[07:47:53]: ▸ no rule to process file '....../ios/UIImage-Resize/UIImage+Resize.h' of type sourcecode.c.h for architecture arm64
```

Due `*.m` files includes `*.h` files, we dont needed to compile `*.h` files

Expected:

![image](https://user-images.githubusercontent.com/572096/31950111-920e7e7e-b8e3-11e7-818a-9fd2bdce0738.png)

Thank