### PR TITLE
[Fix] ios 'RSKImageCropper/RSKImageCropper.h' file not found

### DIFF
--- a/ios/imageCropPicker.xcodeproj/project.pbxproj
+++ b/ios/imageCropPicker.xcodeproj/project.pbxproj
@@ -29,6 +29,13 @@
 			remoteGlobalIDString = A5BE393D1B32B49D00ECDF88;
 			remoteInfo = RSKImageCropper;
 		};
+		D4A529261FE2A89E00F2C3A5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 34434E351D6F5EBB00BF5063 /* RSKImageCropper.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = A5BE393C1B32B49D00ECDF88;
+			remoteInfo = RSKImageCropper;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -126,6 +133,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				D4A529271FE2A89E00F2C3A5 /* PBXTargetDependency */,
 			);
 			name = imageCropPicker;
 			productName = picker;
@@ -207,6 +215,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D4A529271FE2A89E00F2C3A5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSKImageCropper;
+			targetProxy = D4A529261FE2A89E00F2C3A5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		3400A80F1CEB54A6008A0BC7 /* Debug */ = {


### PR DESCRIPTION
## problem

ios build occasionally fails.

```
=== BUILD TARGET imageCropPicker OF PROJECT imageCropPicker WITH CONFIGURATION Release ===
~~~
#import <RSKImageCropper/RSKImageCropper.h>
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
~~~
** ARCHIVE FAILED **
```

## env

- react-native 0.47.1
- react-native-image-crop-picker 0.19.0
- RSKImageCropper 2.0.0
- QBImagePickerController 3.4.0
- Xcode 9.1

## causing

I looked at the log of xcodebuild.
The build order is different each time.
It seems to be an error if imageCropPicker is build before RSKImageCropper.

```
=== BUILD TARGET RSKImageCropper OF PROJECT RSKImageCropper WITH CONFIGURATION Release ===
~~~
=== BUILD TARGET imageCropPicker OF PROJECT imageCropPicker WITH CONFIGURATION Release ===
~~~
** ARCHIVE SUCCEEDED **
```

```
=== BUILD TARGET imageCropPicker OF PROJECT imageCropPicker WITH CONFIGURATION Release ===
~~~
/path/to/MyReactNativeApp/node_modules/react-native-image-crop-picker/ios/ImageCropPicker.h:26:9: fatal error: 'RSKImageCropper/RSKImageCropper.h' file not found
#import <RSKImageCropper/RSKImageCropper.h>
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
~~~
** ARCHIVE FAILED **
```

## fixes

By adding RSKImageCropper (project) to TargetDependency,
It seems that it was able to guarantee that imageCropPicker will be build after RSKImageCropper.

1. open imageCropPicker.xcodeproj from xcode
2. Build Phases -> Target Dependency -> add RSKImageCropper(RSKImageCropper)

I have build it several times after this fix, but the error no longer appears.

## related issues

- [issues/193 (iOS) RSKImageCropper.h not found](https://github.com/ivpusic/react-native-image-crop-picker/issues/193)
- [issues/232 To use CocoaPod,Then Archive My App It tell me: 'RSKImageCropper/RSKImageCropper.h' file not found](https://github.com/ivpusic/react-native-image-crop-picker/issues/232)
- [issues/428 Archive fails intermittently with](https://github.com/ivpusic/react-native-image-crop-picker/issues/428)
