### PR TITLE
Added all Smart Album types supported by iOS 9.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ ImagePicker.clean().then(() => {
 | minFiles (ios only)                     |            number (default 1)            | Min number of files to select when using `multiple` option |
 | maxFiles (ios only)                     |            number (default 5)            | Max number of files to select when using `multiple` option |
 | waitAnimationEnd (ios only)             |           bool (default true)            | Promise will resolve/reject once ViewController `completion` block is called |
-| smartAlbums (ios only)                  | array (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from      |
+| smartAlbums (ios only)                  | array (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from  (options: Generic, Panoramas, Videos, Favorites, Timelapses, AllHidden, RecentlyAdded, Bursts, SlomoVideos, UserLibrary, SelfPortraits, Screenshots, PhotoStream)    |
 | useFrontCamera (ios only)               |           bool (default false)           | Whether to default to the front/'selfie' camera when opened |
 | compressVideoPreset (ios only)          |      string (default MediumQuality)      | Choose which preset will be used for video compression |
 | compressImageMaxWidth                   |          number (default none)           | Compress image with maximum width        |

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -432,7 +432,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
              @"data": (data) ? data : [NSNull null],
              @"exif": (exif) ? exif : [NSNull null],
              @"cropRect": CGRectIsNull(cropRect) ? [NSNull null] : [ImageCropPicker cgRectToDictionary:cropRect],
-             @"creationDate:": (creationDate) ? [NSString stringWithFormat:@"%.0f", [creationDate timeIntervalSince1970]] : [NSNull null],
+             @"creationDate": (creationDate) ? [NSString stringWithFormat:@"%.0f", [creationDate timeIntervalSince1970]] : [NSNull null],
              @"modificationDate": (modificationDate) ? [NSString stringWithFormat:@"%.0f", [modificationDate timeIntervalSince1970]] : [NSNull null],
              };
 }

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -254,13 +254,21 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
             
             if ([self.options objectForKey:@"smartAlbums"] != nil) {
                 NSDictionary *smartAlbums = @{
-                                              @"UserLibrary" : @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
-                                              @"PhotoStream" : @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
+                                              @"Generic" : @(PHAssetCollectionSubtypeSmartAlbumGeneric),
                                               @"Panoramas" : @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
                                               @"Videos" : @(PHAssetCollectionSubtypeSmartAlbumVideos),
+                                              @"Favorites" : @(PHAssetCollectionSubtypeSmartAlbumFavorites),
+                                              @"Timelapses" : @(PHAssetCollectionSubtypeSmartAlbumTimelapses),
+                                              @"AllHidden" : @(PHAssetCollectionSubtypeSmartAlbumAllHidden),
+                                              @"RecentlyAdded" : @(PHAssetCollectionSubtypeSmartAlbumRecentlyAdded),
                                               @"Bursts" : @(PHAssetCollectionSubtypeSmartAlbumBursts),
+                                              @"SlomoVideos" : @(PHAssetCollectionSubtypeSmartAlbumSlomoVideos),
+                                              @"UserLibrary" : @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+                                              @"SelfPortraits" : @(PHAssetCollectionSubtypeSmartAlbumSelfPortraits),
+                                              @"Screenshots" : @(PHAssetCollectionSubtypeSmartAlbumScreenshots),
+                                              @"PhotoStream" : @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
                                               };
-                NSMutableArray *albumsToShow = [NSMutableArray arrayWithCapacity:5];
+                NSMutableArray *albumsToShow = [NSMutableArray arrayWithCapacity:13];
                 for (NSString* album in [self.options objectForKey:@"smartAlbums"]) {
                     if ([smartAlbums objectForKey:album] != nil) {
                         [albumsToShow addObject:[smartAlbums objectForKey:album]];


### PR DESCRIPTION
I added some more Smart Album types, limited to those supported by iOS 9.0+

I've seen in the issues that it is believed these are limited by the `QBImagePicker` library, but from my testing that is not the case. Any `phassetcollectionsubtype` should work out of the box with that library, as far as I can tell. You may test as necessary.

Others available are:
- smartAlbumDepthEffect (iOS 10.2+)
- smartAlbumLivePhotos (iOS 10.3+)
- smartAlbumAnimated (iOS 11.0+)
- smartAlbumLongExposures (iOS 11.0+)

These could be added as well, but I was concerned about compatibility for some developers. If you'd like them included, I can add and resubmit.
