### PR TITLE
Add support for all types of smart albums (selfies, time lapses, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ ImagePicker.clean().then(() => {
 | minFiles (ios only)                     |            number (default 1)            | Min number of files to select when using `multiple` option |
 | maxFiles (ios only)                     |            number (default 5)            | Max number of files to select when using `multiple` option |
 | waitAnimationEnd (ios only)             |           bool (default true)            | Promise will resolve/reject once ViewController `completion` block is called |
-| smartAlbums (ios only)                  | array (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from      |
+| smartAlbums (ios only)                  | array (supported values: ['PhotoStream','Generic','Panoramas','Videos','Favorites','Timepalses','AllHidden','RecentlyAdded','Bursts','SlomoVideos','UserLibrary','SelfPortraits','Screenshots','DepthEffect','LivePhotos','Animated','LongExposure']) (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from      |
 | useFrontCamera (ios only)               |           bool (default false)           | Whether to default to the front/'selfie' camera when opened |
 | compressVideoPreset (ios only)          |      string (default MediumQuality)      | Choose which preset will be used for video compression |
 | compressImageMaxWidth                   |          number (default none)           | Compress image with maximum width        |

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ ImagePicker.clean().then(() => {
 | minFiles (ios only)                     |            number (default 1)            | Min number of files to select when using `multiple` option |
 | maxFiles (ios only)                     |            number (default 5)            | Max number of files to select when using `multiple` option |
 | waitAnimationEnd (ios only)             |           bool (default true)            | Promise will resolve/reject once ViewController `completion` block is called |
-| smartAlbums (ios only)                  | array (supported values: ['PhotoStream','Generic','Panoramas','Videos','Favorites','Timepalses','AllHidden','RecentlyAdded','Bursts','SlomoVideos','UserLibrary','SelfPortraits','Screenshots','DepthEffect','LivePhotos','Animated','LongExposure']) (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from      |
+| smartAlbums (ios only)                  | array (supported values: ['PhotoStream', 'Generic', 'Panoramas', 'Videos', 'Favorites', 'Timepalses', 'AllHidden', 'RecentlyAdded', 'Bursts', 'SlomoVideos', 'UserLibrary', 'SelfPortraits', 'Screenshots', 'DepthEffect', 'LivePhotos', 'Animated', 'LongExposure']) (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from      |
 | useFrontCamera (ios only)               |           bool (default false)           | Whether to default to the front/'selfie' camera when opened |
 | compressVideoPreset (ios only)          |      string (default MediumQuality)      | Choose which preset will be used for video compression |
 | compressImageMaxWidth                   |          number (default none)           | Compress image with maximum width        |

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -254,11 +254,26 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
             
             if ([self.options objectForKey:@"smartAlbums"] != nil) {
                 NSDictionary *smartAlbums = @{
-                                              @"UserLibrary" : @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+                                              //cloud albums
                                               @"PhotoStream" : @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
+
+                                              //smart albums
+                                              @"Generic" : @(PHAssetCollectionSubtypeSmartAlbumGeneric),
                                               @"Panoramas" : @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
                                               @"Videos" : @(PHAssetCollectionSubtypeSmartAlbumVideos),
+                                              @"Favorites" : @(PHAssetCollectionSubtypeSmartAlbumFavorites),
+                                              @"Timepalses" : @(PHAssetCollectionSubtypeSmartAlbumTimelapses),
+                                              @"AllHidden" : @(PHAssetCollectionSubtypeSmartAlbumAllHidden),
+                                              @"RecentlyAdded" : @(PHAssetCollectionSubtypeSmartAlbumRecentlyAdded),
                                               @"Bursts" : @(PHAssetCollectionSubtypeSmartAlbumBursts),
+                                              @"SlomoVideos" : @(PHAssetCollectionSubtypeSmartAlbumSlomoVideos),
+                                              @"UserLibrary" : @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+                                              @"SelfPortraits" : @(PHAssetCollectionSubtypeSmartAlbumSelfPortraits),
+                                              @"Screenshots" : @(PHAssetCollectionSubtypeSmartAlbumScreenshots),
+                                              @"DepthEffect" : @(PHAssetCollectionSubtypeSmartAlbumDepthEffect),
+                                              @"LivePhotos" : @(PHAssetCollectionSubtypeSmartAlbumLivePhotos),
+                                              @"Animated" : @(PHAssetCollectionSubtypeSmartAlbumAnimated),
+                                              @"LongExposure" : @(PHAssetCollectionSubtypeSmartAlbumLongExposures),
                                               };
                 NSMutableArray *albumsToShow = [NSMutableArray arrayWithCapacity:5];
                 for (NSString* album in [self.options objectForKey:@"smartAlbums"]) {


### PR DESCRIPTION
Until now the user could only choose to show smart albums from the default set of 5 albums ('UserLibrary', 'PhotoStream', 'Panoramas', 'Bursts', 'Videos').

I fixed it and added support for all types of smartAlbums, as listed here:
https://developer.apple.com/documentation/photos/phassetcollectionsubtype/phassetcollectionsubtypesmartalbumgeneric

In the future we can add support for the other types of album subtypes, including the wildcard "any" (listed here: https://developer.apple.com/documentation/photos/phassetcollectionsubtype)