### PR TITLE
fix typo in creationDate property in response

### DIFF
--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -439,7 +439,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
              @"data": (data) ? data : [NSNull null],
              @"exif": (exif) ? exif : [NSNull null],
              @"cropRect": CGRectIsNull(cropRect) ? [NSNull null] : [ImageCropPicker cgRectToDictionary:cropRect],
-             @"creationDate:": (creationDate) ? [NSString stringWithFormat:@"%.0f", [creationDate timeIntervalSince1970]] : [NSNull null],
+             @"creationDate": (creationDate) ? [NSString stringWithFormat:@"%.0f", [creationDate timeIntervalSince1970]] : [NSNull null],
              @"modificationDate": (modificationDate) ? [NSString stringWithFormat:@"%.0f", [modificationDate timeIntervalSince1970]] : [NSNull null],
              };
 }


### PR DESCRIPTION
There was an extra colon in the response property for creationDate. There is no more ✅