### PR TITLE
Add option for writing temporary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ ImagePicker.clean().then(() => {
 | width                                   |                  number                  | Width of result image when used with `cropping` option |
 | height                                  |                  number                  | Height of result image when used with `cropping` option |
 | multiple                                |           bool (default false)           | Enable or disable multiple image selection |
+| writeTempFile (ios only)                |           bool (default true)            | When set to false, does not write temporary files for the selected images. This is useful to improve performance when you are retrieving file contents with the `includeBase64` option and don't need to read files from disk. |
 | includeBase64                           |           bool (default false)           | Enable or disable returning base64 data with image |
 | includeExif                           |           bool (default false)           | Include image exif data in the response |
 | cropperActiveWidgetColor (android only) |       string (default `"#424242"`)       | When cropping image, determines ActiveWidget color. |
@@ -132,7 +133,7 @@ ImagePicker.clean().then(() => {
 
 | Property                  |  Type  | Description                              |
 | ------------------------- | :----: | :--------------------------------------- |
-| path                      | string | Selected image location                  |
+| path                      | string | Selected image location. This is null when the `writeTempFile` option is set to false. |
 | localIdentifier(ios only) | string | Selected images' localidentifier, used for PHAsset searching |
 | sourceURL(ios only)       | string | Selected images' source path, do not have write access |
 | filename(ios only)        | string | Selected images' filename                |

--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -50,6 +50,7 @@ RCT_EXPORT_MODULE();
                                 @"multiple": @NO,
                                 @"cropping": @NO,
                                 @"cropperCircleOverlay": @NO,
+                                @"writeTempFile": @YES,
                                 @"includeBase64": @NO,
                                 @"includeExif": @NO,
                                 @"compressVideo": @YES,
@@ -428,7 +429,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 
 - (NSDictionary*) createAttachmentResponse:(NSString*)filePath withExif:(NSDictionary*) exif withSourceURL:(NSString*)sourceURL withLocalIdentifier:(NSString*)localIdentifier withFilename:(NSString*)filename withWidth:(NSNumber*)width withHeight:(NSNumber*)height withMime:(NSString*)mime withSize:(NSNumber*)size withData:(NSString*)data withRect:(CGRect)cropRect withCreationDate:(NSDate*)creationDate withModificationDate:(NSDate*)modificationDate {
     return @{
-             @"path": filePath,
+             @"path": (filePath && ![filePath isEqualToString:(@"")]) ? filePath : [NSNull null],
              @"sourceURL": (sourceURL) ? sourceURL : [NSNull null],
              @"localIdentifier": (localIdentifier) ? localIdentifier : [NSNull null],
              @"filename": (filename) ? filename : [NSNull null],
@@ -543,15 +544,19 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                      imageResult = [self.compression compressImage:[imgT fixOrientation] withOptions:self.options];
                                  }
 
-                                 NSString *filePath = [self persistFile:imageResult.data];
-                                 
-                                 if (filePath == nil) {
-                                     [indicatorView stopAnimating];
-                                     [overlayView removeFromSuperview];
-                                     [imagePickerController dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
-                                         self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
-                                     }]];
-                                     return;
+                                 NSString *filePath = @"";
+                                 if([[self.options objectForKey:@"writeTempFile"] boolValue]) {
+
+                                     filePath = [self persistFile:imageResult.data];
+
+                                     if (filePath == nil) {
+                                         [indicatorView stopAnimating];
+                                         [overlayView removeFromSuperview];
+                                         [imagePickerController dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
+                                             self.reject(ERROR_CANNOT_SAVE_IMAGE_KEY, ERROR_CANNOT_SAVE_IMAGE_MSG, nil);
+                                         }]];
+                                         return;
+                                     }
                                  }
                                  
                                  NSDictionary* exif = nil;


### PR DESCRIPTION
Disk i/o is slow. When I use the `includeBase64` option to retrieve file contents directly, I have no use for a temporary file written to disk.

This PR adds a `writeTempFile` option (default true) that I can use to skip writing of those temporary files.

iOS only.