### PR TITLE
Add cloud support (Android)

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -16,6 +16,7 @@ import android.provider.MediaStore;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.FileProvider;
 import android.util.Base64;
+import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import com.facebook.react.bridge.ActivityEventListener;
@@ -317,22 +318,24 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     private void initiatePicker(final Activity activity) {
         try {
-            final Intent galleryIntent = new Intent(Intent.ACTION_PICK);
+            final Intent galleryIntent = new Intent(Intent.ACTION_GET_CONTENT);
 
             if (cropping || mediaType.equals("photo")) {
                 galleryIntent.setType("image/*");
             } else if (mediaType.equals("video")) {
                 galleryIntent.setType("video/*");
             } else {
-                galleryIntent.setType("*/*");
-                String[] mimetypes = {"image/*", "video/*"};
-                galleryIntent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
+                galleryIntent.setType("video/*");
+                galleryIntent.setType("image/*");
+                //String[] mimetypes = {"image/*", "video/*"};
+                //galleryIntent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
             }
-            
+
             galleryIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             galleryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple);
-            galleryIntent.setAction(Intent.ACTION_GET_CONTENT);
-            galleryIntent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+            //galleryIntent.setAction(Intent.ACTION_GET_CONTENT);
+            //galleryIntent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+            galleryIntent.addCategory(Intent.CATEGORY_OPENABLE);
 
             final Intent chooserIntent = Intent.createChooser(galleryIntent, "Pick an image");
             activity.startActivityForResult(chooserIntent, IMAGE_PICKER_REQUEST);
@@ -425,6 +428,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private void getAsyncSelection(final Activity activity, Uri uri, boolean isCamera) throws Exception {
+        Log.d("CROP_PICKER", uri.toString());
         String path = resolveRealPath(activity, uri, isCamera);
         if (path == null || path.isEmpty()) {
             resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, "Cannot resolve asset path.");
@@ -492,7 +496,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         }).run();
     }
 
-    private String resolveRealPath(Activity activity, Uri uri, boolean isCamera) {
+    private String resolveRealPath(Activity activity, Uri uri, boolean isCamera) throws IOException {
         String path;
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
@@ -619,6 +623,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                     // only one image selected
                     if (clipData == null) {
                         resultCollector.setWaitCount(1);
+                        Log.d("CROP_PICKER", data.toString());
                         getAsyncSelection(activity, data.getData(), false);
                     } else {
                         resultCollector.setWaitCount(clipData.getItemCount());

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -16,7 +16,6 @@ import android.provider.MediaStore;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.FileProvider;
 import android.util.Base64;
-import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import com.facebook.react.bridge.ActivityEventListener;
@@ -327,14 +326,10 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             } else {
                 galleryIntent.setType("video/*");
                 galleryIntent.setType("image/*");
-                //String[] mimetypes = {"image/*", "video/*"};
-                //galleryIntent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
             }
 
             galleryIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             galleryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple);
-            //galleryIntent.setAction(Intent.ACTION_GET_CONTENT);
-            //galleryIntent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
             galleryIntent.addCategory(Intent.CATEGORY_OPENABLE);
 
             final Intent chooserIntent = Intent.createChooser(galleryIntent, "Pick an image");
@@ -428,7 +423,6 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private void getAsyncSelection(final Activity activity, Uri uri, boolean isCamera) throws Exception {
-        Log.d("CROP_PICKER", uri.toString());
         String path = resolveRealPath(activity, uri, isCamera);
         if (path == null || path.isEmpty()) {
             resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, "Cannot resolve asset path.");
@@ -623,7 +617,6 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                     // only one image selected
                     if (clipData == null) {
                         resultCollector.setWaitCount(1);
-                        Log.d("CROP_PICKER", data.toString());
                         getAsyncSelection(activity, data.getData(), false);
                     } else {
                         resultCollector.setWaitCount(clipData.getItemCount());

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -146,7 +146,7 @@ class RealPathUtil {
         final String[] projection = {
                 MediaStore.MediaColumns.DATA,
                 MediaStore.MediaColumns.DISPLAY_NAME,
-                MediaStore.MediaColumns.MIME_TYPE
+                //MediaStore.MediaColumns.MIME_TYPE
         };
 
         try {
@@ -164,12 +164,12 @@ class RealPathUtil {
                 } else {
                     final MimeTypeMap mime = MimeTypeMap.getSingleton();
                     final int indexDisplayName = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME);
-                    final int indexMimeType = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE);
+                    //final int indexMimeType = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE);
                     String fileName = cursor.getString(indexDisplayName);
-                    String extension = mime.getExtensionFromMimeType(cursor.getString(indexMimeType));
+                    //String extension = mime.getExtensionFromMimeType(cursor.getString(indexMimeType));
                     Log.d("CROP_PICKER", "File name: " + fileName);
-                    Log.d("CROP_PICKER", "File extension: " + extension);
-                    File fileWritten = writeToFile(context, fileName + "." + extension, uri);
+                    //Log.d("CROP_PICKER", "File extension: " + extension);
+                    File fileWritten = writeToFile(context, fileName, uri);
                     Log.d("CROP_PICKER", "File path: " + fileWritten.getAbsolutePath());
                     return fileWritten.getAbsolutePath();
                 }

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -8,8 +8,6 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
-import android.util.Log;
-import android.webkit.MimeTypeMap;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -23,7 +21,6 @@ class RealPathUtil {
 
         // DocumentProvider
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-            Log.d("CROP_PICKER", "kitkat");
             // ExternalStorageProvider
             if (isExternalStorageDocument(uri)) {
                 final String docId = DocumentsContract.getDocumentId(uri);
@@ -50,7 +47,6 @@ class RealPathUtil {
             }
             // DownloadsProvider
             else if (isDownloadsDocument(uri)) {
-                Log.d("CROP_PICKER", "isDownloadsDocument");
                 final String id = DocumentsContract.getDocumentId(uri);
                 final Uri contentUri = ContentUris.withAppendedId(
                         Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
@@ -59,7 +55,6 @@ class RealPathUtil {
             }
             // MediaProvider
             else if (isMediaDocument(uri)) {
-                Log.d("CROP_PICKER", "isMediaDocument");
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");
                 final String type = split[0];
@@ -83,7 +78,6 @@ class RealPathUtil {
         }
         // MediaStore (and general)
         else if ("content".equalsIgnoreCase(uri.getScheme())) {
-            Log.d("CROP_PICKER", "MediaStore");
             // Return the remote address
             if (isGooglePhotosUri(uri))
                 return uri.getLastPathSegment();
@@ -91,7 +85,6 @@ class RealPathUtil {
         }
         // File
         else if ("file".equalsIgnoreCase(uri.getScheme())) {
-            Log.d("CROP_PICKER", "file");
             return uri.getPath();
         }
 
@@ -146,31 +139,20 @@ class RealPathUtil {
         final String[] projection = {
                 MediaStore.MediaColumns.DATA,
                 MediaStore.MediaColumns.DISPLAY_NAME,
-                //MediaStore.MediaColumns.MIME_TYPE
         };
 
         try {
             cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
                     null);
-            Log.d("CROP_PICKER", cursor.toString());
             if (cursor != null && cursor.moveToFirst()) {
                 final int index = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA);
-                Log.d("CROP_PICKER", String.valueOf(index));
-                Log.d("CROP_PICKER", "VALUE -> " + cursor.getString(index));
                 String path = cursor.getString(index);
-
                 if (path != null) {
                     return cursor.getString(index);
                 } else {
-                    final MimeTypeMap mime = MimeTypeMap.getSingleton();
                     final int indexDisplayName = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME);
-                    //final int indexMimeType = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE);
                     String fileName = cursor.getString(indexDisplayName);
-                    //String extension = mime.getExtensionFromMimeType(cursor.getString(indexMimeType));
-                    Log.d("CROP_PICKER", "File name: " + fileName);
-                    //Log.d("CROP_PICKER", "File extension: " + extension);
                     File fileWritten = writeToFile(context, fileName, uri);
-                    Log.d("CROP_PICKER", "File path: " + fileWritten.getAbsolutePath());
                     return fileWritten.getAbsolutePath();
                 }
             }

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -8,171 +8,228 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.util.Log;
+import android.webkit.MimeTypeMap;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 class RealPathUtil {
-  static String getRealPathFromURI(final Context context, final Uri uri) {
+    static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
 
-      final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+        final boolean isKitKat = Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT;
 
-      // DocumentProvider
-      if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-          // ExternalStorageProvider
-          if (isExternalStorageDocument(uri)) {
-              final String docId = DocumentsContract.getDocumentId(uri);
-              final String[] split = docId.split(":");
-              final String type = split[0];
+        // DocumentProvider
+        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+            Log.d("CROP_PICKER", "kitkat");
+            // ExternalStorageProvider
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
 
-              if ("primary".equalsIgnoreCase(type)) {
-                  return Environment.getExternalStorageDirectory() + "/" + split[1];
-              } else {
-                final int splitIndex = docId.indexOf(':', 1);
-                final String tag = docId.substring(0, splitIndex);
-                final String path = docId.substring(splitIndex + 1);
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                } else {
+                    final int splitIndex = docId.indexOf(':', 1);
+                    final String tag = docId.substring(0, splitIndex);
+                    final String path = docId.substring(splitIndex + 1);
 
-                String nonPrimaryVolume = getPathToNonPrimaryVolume(context, tag);
-                if (nonPrimaryVolume != null) {
-                    String result = nonPrimaryVolume + "/" + path;
-                    File file = new File(result);
-                    if (file.exists() && file.canRead()) {
-                        return result;
+                    String nonPrimaryVolume = getPathToNonPrimaryVolume(context, tag);
+                    if (nonPrimaryVolume != null) {
+                        String result = nonPrimaryVolume + "/" + path;
+                        File file = new File(result);
+                        if (file.exists() && file.canRead()) {
+                            return result;
+                        }
+                        return null;
                     }
-                    return null;
                 }
-              }
-          }
-          // DownloadsProvider
-          else if (isDownloadsDocument(uri)) {
+            }
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+                Log.d("CROP_PICKER", "isDownloadsDocument");
+                final String id = DocumentsContract.getDocumentId(uri);
+                final Uri contentUri = ContentUris.withAppendedId(
+                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
 
-              final String id = DocumentsContract.getDocumentId(uri);
-              final Uri contentUri = ContentUris.withAppendedId(
-                      Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+                return getDataColumn(context, contentUri, null, null);
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                Log.d("CROP_PICKER", "isMediaDocument");
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
 
-              return getDataColumn(context, contentUri, null, null);
-          }
-          // MediaProvider
-          else if (isMediaDocument(uri)) {
-              final String docId = DocumentsContract.getDocumentId(uri);
-              final String[] split = docId.split(":");
-              final String type = split[0];
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
 
-              Uri contentUri = null;
-              if ("image".equals(type)) {
-                  contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-              } else if ("video".equals(type)) {
-                  contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-              } else if ("audio".equals(type)) {
-                  contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-              }
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] {
+                        split[1]
+                };
 
-              final String selection = "_id=?";
-              final String[] selectionArgs = new String[] {
-                      split[1]
-              };
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+        }
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            Log.d("CROP_PICKER", "MediaStore");
+            // Return the remote address
+            if (isGooglePhotosUri(uri))
+                return uri.getLastPathSegment();
+            return getDataColumn(context, uri, null, null);
+        }
+        // File
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            Log.d("CROP_PICKER", "file");
+            return uri.getPath();
+        }
 
-              return getDataColumn(context, contentUri, selection, selectionArgs);
-          }
-      }
-      // MediaStore (and general)
-      else if ("content".equalsIgnoreCase(uri.getScheme())) {
+        return null;
+    }
 
-          // Return the remote address
-          if (isGooglePhotosUri(uri))
-              return uri.getLastPathSegment();
+    /**
+     * If an image/video has been selected from a cloud storage, this method
+     * should be call to download the file in the cache folder.
+     *
+     * @param context The context
+     * @param fileName donwloaded file's name
+     * @param uri file's URI
+     * @return file that has been written
+     */
+    private static File writeToFile(Context context, String fileName, Uri uri) {
+        String tmpDir = context.getCacheDir() + "/react-native-image-crop-picker";
+        Boolean created = new File(tmpDir).mkdir();
+        File path = new File(tmpDir);
+        File file = new File(path, fileName);
+        try {
+            FileOutputStream oos = new FileOutputStream(file);
+            byte[] buf = new byte[8192];
+            InputStream is = context.getContentResolver().openInputStream(uri);
+            int c = 0;
+            while ((c = is.read(buf, 0, buf.length)) > 0) {
+                oos.write(buf, 0, c);
+                oos.flush();
+            }
+            oos.close();
+            is.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return file;
+    }
 
-          return getDataColumn(context, uri, null, null);
-      }
-      // File
-      else if ("file".equalsIgnoreCase(uri.getScheme())) {
-          return uri.getPath();
-      }
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     * @param selection (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     */
+    private static String getDataColumn(Context context, Uri uri, String selection,
+                                        String[] selectionArgs) {
 
-      return null;
-  }
+        Cursor cursor = null;
+        final String[] projection = {
+                MediaStore.MediaColumns.DATA,
+                MediaStore.MediaColumns.DISPLAY_NAME,
+                MediaStore.MediaColumns.MIME_TYPE
+        };
 
-  /**
-   * Get the value of the data column for this Uri. This is useful for
-   * MediaStore Uris, and other file-based ContentProviders.
-   *
-   * @param context The context.
-   * @param uri The Uri to query.
-   * @param selection (Optional) Filter used in the query.
-   * @param selectionArgs (Optional) Selection arguments used in the query.
-   * @return The value of the _data column, which is typically a file path.
-   */
-  private static String getDataColumn(Context context, Uri uri, String selection,
-                                      String[] selectionArgs) {
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            Log.d("CROP_PICKER", cursor.toString());
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA);
+                Log.d("CROP_PICKER", String.valueOf(index));
+                Log.d("CROP_PICKER", "VALUE -> " + cursor.getString(index));
+                String path = cursor.getString(index);
 
-      Cursor cursor = null;
-      final String column = "_data";
-      final String[] projection = {
-              column
-      };
+                if (path != null) {
+                    return cursor.getString(index);
+                } else {
+                    final MimeTypeMap mime = MimeTypeMap.getSingleton();
+                    final int indexDisplayName = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME);
+                    final int indexMimeType = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE);
+                    String fileName = cursor.getString(indexDisplayName);
+                    String extension = mime.getExtensionFromMimeType(cursor.getString(indexMimeType));
+                    Log.d("CROP_PICKER", "File name: " + fileName);
+                    Log.d("CROP_PICKER", "File extension: " + extension);
+                    File fileWritten = writeToFile(context, fileName + "." + extension, uri);
+                    Log.d("CROP_PICKER", "File path: " + fileWritten.getAbsolutePath());
+                    return fileWritten.getAbsolutePath();
+                }
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
 
-      try {
-          cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
-                  null);
-          if (cursor != null && cursor.moveToFirst()) {
-              final int index = cursor.getColumnIndexOrThrow(column);
-              return cursor.getString(index);
-          }
-      } finally {
-          if (cursor != null)
-              cursor.close();
-      }
-      return null;
-  }
 
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     */
+    private static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
 
-  /**
-   * @param uri The Uri to check.
-   * @return Whether the Uri authority is ExternalStorageProvider.
-   */
-  private static boolean isExternalStorageDocument(Uri uri) {
-      return "com.android.externalstorage.documents".equals(uri.getAuthority());
-  }
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    private static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
 
-  /**
-   * @param uri The Uri to check.
-   * @return Whether the Uri authority is DownloadsProvider.
-   */
-  private static boolean isDownloadsDocument(Uri uri) {
-      return "com.android.providers.downloads.documents".equals(uri.getAuthority());
-  }
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    private static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
 
-  /**
-   * @param uri The Uri to check.
-   * @return Whether the Uri authority is MediaProvider.
-   */
-  private static boolean isMediaDocument(Uri uri) {
-      return "com.android.providers.media.documents".equals(uri.getAuthority());
-  }
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is Google Photos.
+     */
+    private static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
 
-  /**
-   * @param uri The Uri to check.
-   * @return Whether the Uri authority is Google Photos.
-   */
-  private static boolean isGooglePhotosUri(Uri uri) {
-      return "com.google.android.apps.photos.content".equals(uri.getAuthority());
-  }
-
-  private static String getPathToNonPrimaryVolume(Context context, String tag) {
-      File[] volumes = context.getExternalCacheDirs();
-      if (volumes != null) {
-          for (File volume : volumes) {
-              if (volume != null) {
-                  String path = volume.getAbsolutePath();
-                  if (path != null) {
-                      int index = path.indexOf(tag);
-                      if (index != -1) {
-                          return path.substring(0, index) + tag;
-                      }
-                  }
-              }
-          }
-      }
-      return null;
-  }
+    private static String getPathToNonPrimaryVolume(Context context, String tag) {
+        File[] volumes = context.getExternalCacheDirs();
+        if (volumes != null) {
+            for (File volume : volumes) {
+                if (volume != null) {
+                    String path = volume.getAbsolutePath();
+                    if (path != null) {
+                        int index = path.indexOf(tag);
+                        if (index != -1) {
+                            return path.substring(0, index) + tag;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
 }


### PR DESCRIPTION
**Current Behavior:**
If the user select an image in a cloud folder (drive for example) the picker return a path equal to null and throw an exception (see #645).

**Behavior expected with this PR:**
When the URI is local, the file is dowloaded and added to the cache directory. Nothing has changed. The only thing is that now an image from a cloud storage can be selected and is available in the local storage (cache).
The files downloaded are stored in the same cache folder, therefore `clean()`method will remove them.

**Tests:**
- Real device:
  Android 7.0

- Emulator:
  Android 8.0
  Android 4.4