### PR TITLE
Add UIDocumentPickerViewController -- iCloud support (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ ImagePicker.openCamera({
 });
 ```
 
+### Select from file (iOS only)
+
+This is not available on android as the android picker let the user select file from cloud storage.
+
+```javascript
+ImagePicker.openFile({
+}).then(image => {
+  console.log(image);
+});
+```
+
+**The `multiple` property has not been implemented yet -- coming soon**
+
 ### Crop picture
 
 ```javascript
@@ -98,7 +111,7 @@ ImagePicker.clean().then(() => {
 | cropping                                |           bool (default false)           | Enable or disable cropping               |
 | width                                   |                  number                  | Width of result image when used with `cropping` option |
 | height                                  |                  number                  | Height of result image when used with `cropping` option |
-| multiple                                |           bool (default false)           | Enable or disable multiple image selection |
+| multiple                                |           bool (default false)           | Enable or disable multiple image selection (not available for `openFile()`) |
 | writeTempFile (ios only)                |           bool (default true)            | When set to false, does not write temporary files for the selected images. This is useful to improve performance when you are retrieving file contents with the `includeBase64` option and don't need to read files from disk. |
 | includeBase64                           |           bool (default false)           | Enable or disable returning base64 data with image |
 | includeExif                           |           bool (default false)           | Include image exif data in the response |
@@ -135,7 +148,7 @@ ImagePicker.clean().then(() => {
 | Property                  |  Type  | Description                              |
 | ------------------------- | :----: | :--------------------------------------- |
 | path                      | string | Selected image location. This is null when the `writeTempFile` option is set to false. |
-| localIdentifier(ios only) | string | Selected images' localidentifier, used for PHAsset searching |
+| localIdentifier(ios only, allways null with `openFile()`) | string | Selected images' localidentifier, used for PHAsset searching |
 | sourceURL(ios only)       | string | Selected images' source path, do not have write access |
 | filename(ios only)        | string | Selected images' filename                |
 | width                     | number | Selected image width                     |

--- a/ios/src/ImageCropPicker.h
+++ b/ios/src/ImageCropPicker.h
@@ -36,6 +36,7 @@
 @interface ImageCropPicker : NSObject<
 UIImagePickerControllerDelegate,
 UINavigationControllerDelegate,
+UIDocumentPickerDelegate,
 RCTBridgeModule,
 QBImagePickerControllerDelegate,
 RSKImageCropViewControllerDelegate,

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -275,33 +275,42 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
             imagePickerController.maximumNumberOfSelection = abs([[self.options objectForKey:@"maxFiles"] intValue]);
             imagePickerController.showsNumberOfSelectedAssets = [[self.options objectForKey:@"showsSelectedCount"] boolValue];
 
-            if ([self.options objectForKey:@"smartAlbums"] != nil) {
-                NSDictionary *smartAlbums = @{
-                                              //cloud albums
-                                              @"PhotoStream" : @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
-
-                                              //smart albums
-                                              @"Generic" : @(PHAssetCollectionSubtypeSmartAlbumGeneric),
-                                              @"Panoramas" : @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
-                                              @"Videos" : @(PHAssetCollectionSubtypeSmartAlbumVideos),
-                                              @"Favorites" : @(PHAssetCollectionSubtypeSmartAlbumFavorites),
-                                              @"Timelapses" : @(PHAssetCollectionSubtypeSmartAlbumTimelapses),
-                                              @"AllHidden" : @(PHAssetCollectionSubtypeSmartAlbumAllHidden),
-                                              @"RecentlyAdded" : @(PHAssetCollectionSubtypeSmartAlbumRecentlyAdded),
-                                              @"Bursts" : @(PHAssetCollectionSubtypeSmartAlbumBursts),
-                                              @"SlomoVideos" : @(PHAssetCollectionSubtypeSmartAlbumSlomoVideos),
-                                              @"UserLibrary" : @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
-                                              @"SelfPortraits" : @(PHAssetCollectionSubtypeSmartAlbumSelfPortraits),
-                                              @"Screenshots" : @(PHAssetCollectionSubtypeSmartAlbumScreenshots),
-                                              @"DepthEffect" : @(PHAssetCollectionSubtypeSmartAlbumDepthEffect),
-                                              @"LivePhotos" : @(PHAssetCollectionSubtypeSmartAlbumLivePhotos),
-                                              @"Animated" : @(PHAssetCollectionSubtypeSmartAlbumAnimated),
-                                              @"LongExposure" : @(PHAssetCollectionSubtypeSmartAlbumLongExposures),
-                                              };
-                NSMutableArray *albumsToShow = [NSMutableArray arrayWithCapacity:5];
-                for (NSString* album in [self.options objectForKey:@"smartAlbums"]) {
-                    if ([smartAlbums objectForKey:album] != nil) {
-                        [albumsToShow addObject:[smartAlbums objectForKey:album]];
+            NSArray *smartAlbums = [self.options objectForKey:@"smartAlbums"];
+            if (smartAlbums != nil) {
+                NSDictionary *albums = @{
+                                         //user albums
+                                         @"Regular" : @(PHAssetCollectionSubtypeAlbumRegular),
+                                         @"SyncedEvent" : @(PHAssetCollectionSubtypeAlbumSyncedEvent),
+                                         @"SyncedFaces" : @(PHAssetCollectionSubtypeAlbumSyncedFaces),
+                                         @"SyncedAlbum" : @(PHAssetCollectionSubtypeAlbumSyncedAlbum),
+                                         @"Imported" : @(PHAssetCollectionSubtypeAlbumImported),
+                                         
+                                         //cloud albums
+                                         @"PhotoStream" : @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
+                                         @"CloudShared" : @(PHAssetCollectionSubtypeAlbumCloudShared),
+                                         
+                                         //smart albums
+                                         @"Generic" : @(PHAssetCollectionSubtypeSmartAlbumGeneric),
+                                         @"Panoramas" : @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
+                                         @"Videos" : @(PHAssetCollectionSubtypeSmartAlbumVideos),
+                                         @"Favorites" : @(PHAssetCollectionSubtypeSmartAlbumFavorites),
+                                         @"Timelapses" : @(PHAssetCollectionSubtypeSmartAlbumTimelapses),
+                                         @"AllHidden" : @(PHAssetCollectionSubtypeSmartAlbumAllHidden),
+                                         @"RecentlyAdded" : @(PHAssetCollectionSubtypeSmartAlbumRecentlyAdded),
+                                         @"Bursts" : @(PHAssetCollectionSubtypeSmartAlbumBursts),
+                                         @"SlomoVideos" : @(PHAssetCollectionSubtypeSmartAlbumSlomoVideos),
+                                         @"UserLibrary" : @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+                                         @"SelfPortraits" : @(PHAssetCollectionSubtypeSmartAlbumSelfPortraits),
+                                         @"Screenshots" : @(PHAssetCollectionSubtypeSmartAlbumScreenshots),
+                                         @"DepthEffect" : @(PHAssetCollectionSubtypeSmartAlbumDepthEffect),
+                                         @"LivePhotos" : @(PHAssetCollectionSubtypeSmartAlbumLivePhotos),
+                                         @"Animated" : @(PHAssetCollectionSubtypeSmartAlbumAnimated),
+                                         @"LongExposure" : @(PHAssetCollectionSubtypeSmartAlbumLongExposures),
+                                         };
+                NSMutableArray *albumsToShow = [NSMutableArray arrayWithCapacity:smartAlbums.count];
+                for (NSString* smartAlbum in smartAlbums) {
+                    if ([albums objectForKey:smartAlbum] != nil) {
+                        [albumsToShow addObject:[albums objectForKey:smartAlbum]];
                     }
                 }
                 imagePickerController.assetCollectionSubtypes = albumsToShow;

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -972,7 +972,6 @@ RCT_EXPORT_METHOD(openFile:(NSDictionary *)options
                     NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:newURL.path error:&attributesError];
                     if(!attributesError) {
                         if ([mimeTypeString containsString:@"image"]) {
-                            NSLog(@"This is an image");
                             NSDictionary* exif;
                             NSData *data = [NSData dataWithContentsOfURL:url];
                             if([[self.options objectForKey:@"includeExif"] boolValue]) {
@@ -990,7 +989,6 @@ RCT_EXPORT_METHOD(openFile:(NSDictionary *)options
                             });
                         } else {
                             [self showActivityIndicator:^(UIActivityIndicatorView *indicatorView, UIView *overlayView) {
-                                NSLog(@"This is a video");
                                 // create temp file
                                 NSString *tmpDirFullPath = [self getTmpDirectory];
                                 NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
@@ -1046,9 +1044,7 @@ RCT_EXPORT_METHOD(openFile:(NSDictionary *)options
     
 - (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller
 {
-    [controller dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
-        self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
-    }]];
+    self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
 }
 
 @end


### PR DESCRIPTION
This PR introduce the `openFilePicker()` which should works the same way as the `openPicker()` (multiple selection not implemented yet). This method will let the user choose some image or video in the his iCloud storage using the iOS `UIDocumentPickerViewController`.

I tried to use the maximum amount of existing code that I could and to respect the general architecture of the project. I'm not a iOS developer and my knowledge in objective c are really low, so there is maybe some improvements that could be done.