### PR TITLE
Update RNImageCropPicker.podspec

### DIFF
--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.dependency 'RSKImageCropper'
   s.dependency 'QBImagePickerController'
+  s.dependency 'React/Core'
 end


### PR DESCRIPTION
fix 'RCTBridgeModule.h' file not found
i found that in podsec, The lack of the  dependency about  'React/Core'
#637 