### PR TITLE
Adds React as Dependency

### DIFF
--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/ivpusic/react-native-image-crop-picker", :tag => 'v#{version}'}
   s.source_files = 'ios/src/*.{h,m}'
   s.platform     = :ios, "8.0"
+  s.dependency 'React'
   s.dependency 'RSKImageCropper'
   s.dependency 'QBImagePickerController'
 end


### PR DESCRIPTION
I was experiencing the issue that many people have been describing on https://github.com/ivpusic/react-native-image-crop-picker/issues/414. After looking at https://github.com/adjust/react_native_sdk/pull/22 it appears that we just need to add `React` as a dependency in the podspec.