### PR TITLE
Update TypeScript typings with some Android-only options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,13 @@ declare module "react-native-image-crop-picker" {
         path?: string;
         includeBase64?: boolean;
         includeExif?: boolean;
+        cropperActiveWidgetColor?: string;
+        cropperStatusBarColor?: string;
+        cropperToolbarColor?: string;
+        freeStyleCropEnabled?: boolean;
         cropperTintColor?: string;
         cropperCircleOverlay?: boolean;
+        disableCropperColorSetters?: boolean;
         maxFiles?: number;
         waitAnimationEnd?: boolean;
         smartAlbums?: string[];


### PR DESCRIPTION
Several Android-only options were missing from the TypeScript `Options` interface, causing compiler warnings in client codebases when used.