### PR TITLE
Added support for skipping GIF compression.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ ImagePicker.clean().then(() => {
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |
 | cropperChooseText (ios only)            |           string (default choose)        | Choose button text |
 | cropperCancelText (ios only)            |           string (default Cancel)        | Cancel button text |
+| compressGIF       |           bool (default false)           | Whether to compress GIF images. This will compress the GIF (regardless of set value) when `multiple` is `false` or `cropping` is `true` |
 
 #### Smart Album Types (ios)
 

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -17,12 +17,14 @@ import java.io.IOException;
 
 class Compression {
 
-    File compressImage(final Activity activity, final ReadableMap options, final String originalImagePath) throws IOException {
+    File compressImage(final Activity activity, final ReadableMap options, final String originalImagePath, final String mimeType) throws IOException {
         Integer maxWidth = options.hasKey("compressImageMaxWidth") ? options.getInt("compressImageMaxWidth") : null;
         Integer maxHeight = options.hasKey("compressImageMaxHeight") ? options.getInt("compressImageMaxHeight") : null;
         Double quality = options.hasKey("compressImageQuality") ? options.getDouble("compressImageQuality") : null;
+        Boolean compressGIF = options.hasKey("compressGIF") ? options.getBoolean("compressGIF") : false;
+        Boolean skipCompression = !compressGIF && mimeType.equalsIgnoreCase("image/gif");
 
-        if (maxWidth == null && maxHeight == null && quality == null) {
+        if (skipCompression || (maxWidth == null && maxHeight == null && quality == null)) {
             Log.d("image-crop-picker", "Skipping image compression");
             return new File(originalImagePath);
         }

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -76,6 +76,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     private boolean hideBottomControls = false;
     private boolean enableRotationGesture = false;
     private boolean disableCropperColorSetters = false;
+    private boolean compressGIF = false;
     private ReadableMap options;
 
     //Grey 800
@@ -537,11 +538,11 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         if (path.startsWith("http://") || path.startsWith("https://")) {
             throw new Exception("Cannot select remote files");
         }
-        validateImage(path);
+        BitmapFactory.Options original = validateImage(path);
 
         // if compression options are provided image will be compressed. If none options is provided,
         // then original image will be returned
-        File compressedImage = compression.compressImage(activity, options, path);
+        File compressedImage = compression.compressImage(activity, options, path, original.outMimeType);
         String compressedImagePath = compressedImage.getPath();
         BitmapFactory.Options options = validateImage(compressedImagePath);
         long modificationDate = new File(path).lastModified();

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 class RealPathUtil {
     static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
 
-        final boolean isKitKat = Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT;
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
         // DocumentProvider
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ declare module "react-native-image-crop-picker" {
         enableRotationGesture?: boolean;
         cropperCancelText?: string;
         cropperChooseText?: string;
+        compressGIF?: boolean;
     }
 
     export interface Image {

--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -45,6 +45,14 @@
         result.image = image;
         return result;
     }
+
+    // If both width and height are within the limits just return them
+    if ([maxWidth floatValue] >= image.size.width && [maxHeight floatValue] >= image.size.height) {
+        result.width = [NSNumber numberWithFloat:image.size.width];
+        result.height = [NSNumber numberWithFloat:image.size.height];
+        result.image = image;
+        return result;
+    }
     
     CGFloat oldWidth = image.size.width;
     CGFloat oldHeight = image.size.height;


### PR DESCRIPTION
When users select GIFs they get compressed to static Jpeg images. This PR allows you to skip that compression and thus keep the original GIF image.

There's also some minor fixes with `compressImageMaxWidth` and `compressImageMaxHeight` on iOS. Before it would scale the image to  `compressImageMaxWidth` or `compressImageMaxHeight` even if the image was smaller than those values.