### PR TITLE
[fix/android] Android API version under 19 crash fix

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 class RealPathUtil {
     static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
 
-        final boolean isKitKat = Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT;
+        final boolean isKitKat = Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT;
 
         // DocumentProvider
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {


### PR DESCRIPTION
Thanks for creating awesome project.
Recently I've used this library for small project and everything worked great except on Android 4.2 
( API < 19 ). When I click confirm of cropping, it crashes right away. So I looked up into source code and found out that `import android.provider.DocumentsContract` library is available since Android Kitkat which is API 19 or above. 

This fixes #730 