### PR TITLE
Added android equivalent code for skipping image compression.

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -1,12 +1,15 @@
 package com.reactnative.ivpusic.imagepicker;
 
 import android.app.Activity;
+import android.graphics.BitmapFactory;
 import android.graphics.Bitmap;
 import android.os.Environment;
 import android.util.Log;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
 import id.zelory.compressor.Compressor;
+import java.util.Arrays;
+import java.util.List;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,12 +20,19 @@ import java.io.IOException;
 
 class Compression {
 
-    File compressImage(final Activity activity, final ReadableMap options, final String originalImagePath) throws IOException {
+    File compressImage(final Activity activity, final ReadableMap options, final String originalImagePath, final BitmapFactory.Options bitmapOptions) throws IOException {
         Integer maxWidth = options.hasKey("compressImageMaxWidth") ? options.getInt("compressImageMaxWidth") : null;
         Integer maxHeight = options.hasKey("compressImageMaxHeight") ? options.getInt("compressImageMaxHeight") : null;
         Double quality = options.hasKey("compressImageQuality") ? options.getDouble("compressImageQuality") : null;
 
-        if (maxWidth == null && maxHeight == null && quality == null) {
+        Boolean isLossLess = (quality == null || quality == 1.0);
+        Boolean useOriginalWidth = (maxWidth == null || maxWidth >= bitmapOptions.outWidth);
+        Boolean useOriginalHeight = (maxHeight == null || maxHeight >= bitmapOptions.outHeight);
+
+        List knownMimes = Arrays.asList("image/jpeg", "image/jpg", "image/png", "image/gif", "image/tiff");
+        Boolean isKnownMimeType = (bitmapOptions.mimeType != null && knownMimes.contains(bitmapOptions.mimeType.toLowerCase()));
+
+        if (isLossLess && useOriginalWidth && useOriginalHeight && isKnownMimeType) {
             Log.d("image-crop-picker", "Skipping image compression");
             return new File(originalImagePath);
         }

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -30,7 +30,7 @@ class Compression {
         Boolean useOriginalHeight = (maxHeight == null || maxHeight >= bitmapOptions.outHeight);
 
         List knownMimes = Arrays.asList("image/jpeg", "image/jpg", "image/png", "image/gif", "image/tiff");
-        Boolean isKnownMimeType = (bitmapOptions.mimeType != null && knownMimes.contains(bitmapOptions.mimeType.toLowerCase()));
+        Boolean isKnownMimeType = (bitmapOptions.outMimeType != null && knownMimes.contains(bitmapOptions.outMimeType.toLowerCase()));
 
         if (isLossLess && useOriginalWidth && useOriginalHeight && isKnownMimeType) {
             Log.d("image-crop-picker", "Skipping image compression");

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -537,11 +537,11 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         if (path.startsWith("http://") || path.startsWith("https://")) {
             throw new Exception("Cannot select remote files");
         }
-        validateImage(path);
+        BitmapFactory.Options original = validateImage(path);
 
         // if compression options are provided image will be compressed. If none options is provided,
         // then original image will be returned
-        File compressedImage = compression.compressImage(activity, options, path);
+        File compressedImage = compression.compressImage(activity, options, path, original);
         String compressedImagePath = compressedImage.getPath();
         BitmapFactory.Options options = validateImage(compressedImagePath);
         long modificationDate = new File(path).lastModified();


### PR DESCRIPTION
The updated PR to the old one. The following test have been performed:
GIF (300x 200) and DNG (2000 x 1000) file with the following settings:

```compressQuality: 0.8 ``` -> Converted both to `jpeg`
```compressQuality: 0.8, compressMaxWidth: 100, compressMaxHeight: 100``` -> Converted both to `jpeg`
```compressMaxWidth: 100, compressMaxHeight: 100``` + individually -> Converted both to `jpeg`
```compressQuality: 1``` -> Only converted `DNG` to `jpeg`
```compressQuality: 1, compressMaxWidth: 500, compressMaxHeight: 500``` -> Only converted `DNG` to `jpeg`
```No settings set``` -> Only converted `DNG` to `jpeg`