### PR TITLE
Add boolean `compressVideo` option (iOS only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ ImagePicker.clean().then(() => {
 | waitAnimationEnd (ios only)             |           bool (default true)            | Promise will resolve/reject once ViewController `completion` block is called |
 | smartAlbums (ios only)                  | array ([supported values](https://github.com/ivpusic/react-native-image-crop-picker/blob/master/README.md#smart-album-types-ios)) (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from      |
 | useFrontCamera (ios only)               |           bool (default false)           | Whether to default to the front/'selfie' camera when opened |
+| compressVideo (ios only)                |           bool (default true)            | Whether to compress the selected videos |
 | compressVideoPreset (ios only)          |      string (default MediumQuality)      | Choose which preset will be used for video compression |
 | compressImageMaxWidth                   |          number (default none)           | Compress image with maximum width        |
 | compressImageMaxHeight                  |          number (default none)           | Compress image with maximum height       |
@@ -128,7 +129,7 @@ ImagePicker.clean().then(() => {
 | showCropGuidelines (android only)       |           bool (default true)            | Whether to show the 3x3 grid on top of the image during cropping |
 | hideBottomControls (android only)       |           bool (default false)           | Whether to display bottom controls       |
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |
-| cropperChooseText (ios only)            |           string (default choose)        | Choose button text |
+| cropperChooseText (ios only)            |           string (default choose)        | Choose button text |
 | cropperCancelText (ios only)            |           string (default Cancel)        | Cancel button text |
 
 #### Smart Album Types (ios)

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare module "react-native-image-crop-picker" {
         waitAnimationEnd?: boolean;
         smartAlbums?: string[];
         useFrontCamera?: boolean;
+        compressVideo?: boolean;
         compressVideoPreset?: string;
         compressImageMaxWidth?: number;
         compressImageMaxHeight?: number;

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -427,40 +427,64 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                      NSDictionary *info) {
          NSURL *sourceURL = [(AVURLAsset *)asset URL];
 
-         // create temp file
-         NSString *tmpDirFullPath = [self getTmpDirectory];
-         NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
-         filePath = [filePath stringByAppendingString:@".mp4"];
-         NSURL *outputURL = [NSURL fileURLWithPath:filePath];
+         if ([[[self options] objectForKey:@"compressVideo"] boolValue]) {
+            // create temp compressed file
+            NSString *tmpDirFullPath = [self getTmpDirectory];
+            NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
+            filePath = [filePath stringByAppendingString:@".mp4"];
+            NSURL *outputURL = [NSURL fileURLWithPath:filePath];
 
-         [self.compression compressVideo:sourceURL outputURL:outputURL withOptions:self.options handler:^(AVAssetExportSession *exportSession) {
-             if (exportSession.status == AVAssetExportSessionStatusCompleted) {
-                 AVAsset *compressedAsset = [AVAsset assetWithURL:outputURL];
-                 AVAssetTrack *track = [[compressedAsset tracksWithMediaType:AVMediaTypeVideo] firstObject];
+            [self.compression compressVideo:sourceURL outputURL:outputURL withOptions:self.options handler:^(AVAssetExportSession *exportSession) {
+                if (exportSession.status == AVAssetExportSessionStatusCompleted) {
+                    AVAsset *compressedAsset = [AVAsset assetWithURL:outputURL];
+                    AVAssetTrack *track = [[compressedAsset tracksWithMediaType:AVMediaTypeVideo] firstObject];
 
-                 NSNumber *fileSizeValue = nil;
-                 [outputURL getResourceValue:&fileSizeValue
-                                      forKey:NSURLFileSizeKey
-                                       error:nil];
+                    NSNumber *fileSizeValue = nil;
+                    [outputURL getResourceValue:&fileSizeValue
+                                        forKey:NSURLFileSizeKey
+                                        error:nil];
 
-                 completion([self createAttachmentResponse:[outputURL absoluteString]
-                                                  withExif:nil
-                                             withSourceURL:[sourceURL absoluteString]
-                                       withLocalIdentifier: forAsset.localIdentifier
-                                              withFilename:[forAsset valueForKey:@"filename"]
-                                                 withWidth:[NSNumber numberWithFloat:track.naturalSize.width]
-                                                withHeight:[NSNumber numberWithFloat:track.naturalSize.height]
-                                                  withMime:@"video/mp4"
-                                                  withSize:fileSizeValue
-                                                  withData:nil
-                                                  withRect:CGRectNull
-                                          withCreationDate:forAsset.creationDate
-                                      withModificationDate:forAsset.modificationDate
-                             ]);
-             } else {
-                 completion(nil);
-             }
-         }];
+                    completion([self createAttachmentResponse:[outputURL absoluteString]
+                                                    withExif:nil
+                                                withSourceURL:[sourceURL absoluteString]
+                                        withLocalIdentifier: forAsset.localIdentifier
+                                                withFilename:[forAsset valueForKey:@"filename"]
+                                                    withWidth:[NSNumber numberWithFloat:track.naturalSize.width]
+                                                    withHeight:[NSNumber numberWithFloat:track.naturalSize.height]
+                                                    withMime:@"video/mp4"
+                                                    withSize:fileSizeValue
+                                                    withData:nil
+                                                    withRect:CGRectNull
+                                            withCreationDate:forAsset.creationDate
+                                        withModificationDate:forAsset.modificationDate
+                                ]);
+                } else {
+                    completion(nil);
+                }
+            }];
+         } else {
+             AVAssetTrack *track = [[asset tracksWithMediaType:AVMediaTypeVideo] firstObject];
+             NSNumber *fileSizeValue = nil;
+             [sourceURL getResourceValue:&fileSizeValue
+                                  forKey:NSURLFileSizeKey
+                                   error:nil];
+
+             completion([self createAttachmentResponse:nil
+                                              withExif:nil
+                                         withSourceURL:[sourceURL absoluteString]
+                                   withLocalIdentifier: forAsset.localIdentifier
+                                          withFilename:[forAsset valueForKey:@"filename"]
+                                             withWidth:[NSNumber numberWithFloat:track.naturalSize.width]
+                                            withHeight:[NSNumber numberWithFloat:track.naturalSize.height]
+                                              withMime:@"video/mp4"
+                                              withSize:fileSizeValue
+                                              withData:nil
+                                              withRect:CGRectNull
+                                      withCreationDate:forAsset.creationDate
+                                  withModificationDate:forAsset.modificationDate
+                         ]);
+             return;
+         }
      }];
 }
 


### PR DESCRIPTION
Following up to #134, I need exactly the same functionality as described in [this comment](https://github.com/ivpusic/react-native-image-crop-picker/issues/134#issuecomment-268145969). That is, I need to perform the video compression step as part of another module with a custom progress UI.

The best option until now was to use `compressVideoPreset: "Passthrough"` but that is still slow if you select multiple larger videos (can take several minutes) and consumes unnecessary disk space, even if temporary.

This new `compressVideo` boolean option, when set to false, allows us bypass the video compression step. We can then work with the selected files very easily with the `localIdentifier` property that is returned.

Note that with `compressVideo: false`, the returned `path` property is `null`. Not sure if that makes sense.

If you need any change or improvement, just let me know.




