### PR TITLE
Solves #642 by allowing network access for videos stored in the cloud

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -419,6 +419,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     PHImageManager *manager = [PHImageManager defaultManager];
     PHVideoRequestOptions *options = [[PHVideoRequestOptions alloc] init];
     options.version = PHVideoRequestOptionsVersionOriginal;
+    options.networkAccessAllowed = YES;
 
     [manager
      requestAVAssetForVideo:forAsset


### PR DESCRIPTION
Set options.networkAccessAllowed = YES in getVideoAsset. This will prevent freezing on 'Processing Assets...' when attempting to get videos stored in the cloud.

I referred to https://stackoverflow.com/questions/40446026/phcacheimagemanager-requestavassetforvideo-returns-nil-avasset?rq=1 when investigating this bug. I also noticed that options.networkAccessAllowed was set to YES for photos. So I just set it to YES for videos too.

Thanks for this awesome project!