### PR TITLE
Fix a bug when the file name contains slashes.

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -103,6 +103,7 @@ class RealPathUtil {
     private static File writeToFile(Context context, String fileName, Uri uri) {
         String tmpDir = context.getCacheDir() + "/react-native-image-crop-picker";
         Boolean created = new File(tmpDir).mkdir();
+        fileName = fileName.substring(fileName.lastIndexOf('/') + 1);
         File path = new File(tmpDir);
         File file = new File(path, fileName);
         try {


### PR DESCRIPTION
It can happen when selecting an image downloaded from Weibo app.