### PR TITLE
Adds forceJpg flag to convert live photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ ImagePicker.clean().then(() => {
 | loadingLabelText (ios only)             | string (default "Processing assets...")  | Text displayed while photo is loading in picker |
 | mediaType                               |           string (default any)           | Accepted mediaType for image selection, can be one of: 'photo', 'video', or 'any' |
 | showsSelectedCount (ios only)           |           bool (default true)            | Whether to show the number of selected assets |
-| allowLivePhotos (ios only)           |           bool (default true)            | Whether to use Live Photos. (if true, will return .mpg live photos, if false the static image) |
+| forceJPG (ios only)           |           bool (default false)            | Whether to convert photos to JPG. This will also convert any Live Photo into its JPG representation |
 | showCropGuidelines (android only)       |           bool (default true)            | Whether to show the 3x3 grid on top of the image during cropping |
 | hideBottomControls (android only)       |           bool (default false)           | Whether to display bottom controls       |
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ ImagePicker.clean().then(() => {
 | loadingLabelText (ios only)             | string (default "Processing assets...")  | Text displayed while photo is loading in picker |
 | mediaType                               |           string (default any)           | Accepted mediaType for image selection, can be one of: 'photo', 'video', or 'any' |
 | showsSelectedCount (ios only)           |           bool (default true)            | Whether to show the number of selected assets |
-| forceJPG (ios only)           |           bool (default false)            | Whether to convert photos to JPG. This will also convert any Live Photo into its JPG representation |
+| forceJpg (ios only)           |           bool (default false)            | Whether to convert photos to JPG. This will also convert any Live Photo into its JPG representation |
 | showCropGuidelines (android only)       |           bool (default true)            | Whether to show the 3x3 grid on top of the image during cropping |
 | hideBottomControls (android only)       |           bool (default false)           | Whether to display bottom controls       |
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ ImagePicker.clean().then(() => {
 | loadingLabelText (ios only)             | string (default "Processing assets...")  | Text displayed while photo is loading in picker |
 | mediaType                               |           string (default any)           | Accepted mediaType for image selection, can be one of: 'photo', 'video', or 'any' |
 | showsSelectedCount (ios only)           |           bool (default true)            | Whether to show the number of selected assets |
+| allowLivePhotos (ios only)           |           bool (default true)            | Whether to use Live Photos. (if true, will return .mpg live photos, if false the static image) |
 | showCropGuidelines (android only)       |           bool (default true)            | Whether to show the 3x3 grid on top of the image during cropping |
 | hideBottomControls (android only)       |           bool (default false)           | Whether to display bottom controls       |
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |

--- a/example/app.js
+++ b/example/app.js
@@ -134,7 +134,7 @@ export default class App extends Component {
       multiple: true,
       waitAnimationEnd: false,
       includeExif: true,
-      forgeJPG: true,
+      forgeJpg: true,
     }).then(images => {
       this.setState({
         image: null,

--- a/example/app.js
+++ b/example/app.js
@@ -134,6 +134,7 @@ export default class App extends Component {
       multiple: true,
       waitAnimationEnd: false,
       includeExif: true,
+      forgeJPG: true,
     }).then(images => {
       this.setState({
         image: null,

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare module "react-native-image-crop-picker" {
         loadingLabelText?: string;
         mediaType?: string;
         showsSelectedCount?: boolean;
-        forceJPG?: boolean;
+        forceJpg?: boolean;
         showCropGuidelines?: boolean;
         hideBottomControls?: boolean;
         enableRotationGesture?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare module "react-native-image-crop-picker" {
         loadingLabelText?: string;
         mediaType?: string;
         showsSelectedCount?: boolean;
-        allowLivePhotos?: boolean;
+        forceJPG?: boolean;
         showCropGuidelines?: boolean;
         hideBottomControls?: boolean;
         enableRotationGesture?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ declare module "react-native-image-crop-picker" {
         loadingLabelText?: string;
         mediaType?: string;
         showsSelectedCount?: boolean;
+        allowLivePhotos?: boolean;
         showCropGuidelines?: boolean;
         hideBottomControls?: boolean;
         enableRotationGesture?: boolean;

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -88,7 +88,7 @@ RCT_EXPORT_MODULE();
                                 @"loadingLabelText": @"Processing assets...",
                                 @"mediaType": @"any",
                                 @"showsSelectedCount": @YES,
-                                @"allowLivePhotos": @YES,
+                                @"forceJPG": @NO,
                                 @"cropperCancelText": @"Cancel",
                                 @"cropperChooseText": @"Choose"
                                 };
@@ -277,8 +277,7 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
             imagePickerController.minimumNumberOfSelection = abs([[self.options objectForKey:@"minFiles"] intValue]);
             imagePickerController.maximumNumberOfSelection = abs([[self.options objectForKey:@"maxFiles"] intValue]);
             imagePickerController.showsNumberOfSelectedAssets = [[self.options objectForKey:@"showsSelectedCount"] boolValue];
-            imagePickerController.allowLivePhotos = [[self.options objectForKey:@"allowLivePhotos"] boolValue];
-
+            
             NSArray *smartAlbums = [self.options objectForKey:@"smartAlbums"];
             if (smartAlbums != nil) {
                 NSDictionary *albums = @{
@@ -511,7 +510,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     PHImageRequestOptions* options = [[PHImageRequestOptions alloc] init];
     options.synchronous = NO;
     options.networkAccessAllowed = YES;
-
+    
     if ([[[self options] objectForKey:@"multiple"] boolValue]) {
         NSMutableArray *selections = [[NSMutableArray alloc] init];
 
@@ -561,6 +560,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                              [lock lock];
                              @autoreleasepool {
                                  UIImage *imgT = [UIImage imageWithData:imageData];
+                                 
+                                 Boolean forceJPG = [[self.options valueForKey:@"forceJPG"] boolValue];
 
                                  NSNumber *compressQuality = [self.options valueForKey:@"compressImageQuality"];
                                  Boolean isLossless = (compressQuality == nil || [compressQuality floatValue] >= 0.8);
@@ -575,7 +576,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                  Boolean isKnownMimeType = [mimeType length] > 0;
 
                                  ImageResult *imageResult = [[ImageResult alloc] init];
-                                 if (isLossless && useOriginalWidth && useOriginalHeight && isKnownMimeType) {
+                                 if (isLossless && useOriginalWidth && useOriginalHeight && isKnownMimeType && !forceJPG) {
                                      // Use original, unmodified image
                                      imageResult.data = imageData;
                                      imageResult.width = @(imgT.size.width);

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -88,6 +88,7 @@ RCT_EXPORT_MODULE();
                                 @"loadingLabelText": @"Processing assets...",
                                 @"mediaType": @"any",
                                 @"showsSelectedCount": @YES,
+                                @"allowLivePhotos": @YES,
                                 @"cropperCancelText": @"Cancel",
                                 @"cropperChooseText": @"Choose"
                                 };
@@ -276,6 +277,7 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
             imagePickerController.minimumNumberOfSelection = abs([[self.options objectForKey:@"minFiles"] intValue]);
             imagePickerController.maximumNumberOfSelection = abs([[self.options objectForKey:@"maxFiles"] intValue]);
             imagePickerController.showsNumberOfSelectedAssets = [[self.options objectForKey:@"showsSelectedCount"] boolValue];
+            imagePickerController.allowLivePhotos = [[self.options objectForKey:@"allowLivePhotos"] boolValue];
 
             NSArray *smartAlbums = [self.options objectForKey:@"smartAlbums"];
             if (smartAlbums != nil) {

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -88,7 +88,7 @@ RCT_EXPORT_MODULE();
                                 @"loadingLabelText": @"Processing assets...",
                                 @"mediaType": @"any",
                                 @"showsSelectedCount": @YES,
-                                @"forceJPG": @NO,
+                                @"forceJpg": @NO,
                                 @"cropperCancelText": @"Cancel",
                                 @"cropperChooseText": @"Choose"
                                 };
@@ -561,7 +561,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                              @autoreleasepool {
                                  UIImage *imgT = [UIImage imageWithData:imageData];
                                  
-                                 Boolean forceJPG = [[self.options valueForKey:@"forceJPG"] boolValue];
+                                 Boolean forceJpg = [[self.options valueForKey:@"forceJpg"] boolValue];
 
                                  NSNumber *compressQuality = [self.options valueForKey:@"compressImageQuality"];
                                  Boolean isLossless = (compressQuality == nil || [compressQuality floatValue] >= 0.8);
@@ -576,7 +576,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                  Boolean isKnownMimeType = [mimeType length] > 0;
 
                                  ImageResult *imageResult = [[ImageResult alloc] init];
-                                 if (isLossless && useOriginalWidth && useOriginalHeight && isKnownMimeType && !forceJPG) {
+                                 if (isLossless && useOriginalWidth && useOriginalHeight && isKnownMimeType && !forceJpg) {
                                      // Use original, unmodified image
                                      imageResult.data = imageData;
                                      imageResult.width = @(imgT.size.width);


### PR DESCRIPTION
Adds a `forceJPG` flag to force the lib to convert target images. This will be mostly helpful when images contain Live Images but only Still images are wanted.

How it works:
Calling `UIImageJPEGRepresentation` will force any images to return their JPG equivalent, even if they're Live Photos.