### PR TITLE
Revert to compile

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.yalantis:ucrop:2.2.2-native'
-    implementation 'id.zelory:compressor:2.1.0'
+    compile 'com.facebook.react:react-native:+'
+    compile 'com.github.yalantis:ucrop:2.2.2-native'
+    compile 'id.zelory:compressor:2.1.0'
 }


### PR DESCRIPTION
Revert back to using `compile` to continue support for gradle 2.
 
Fixes https://github.com/ivpusic/react-native-image-crop-picker/issues/795