### PR TITLE
Remove problematic step from manual post-install steps for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ In Xcode open Info.plist and add string key `NSPhotoLibraryUsageDescription` wit
 
 ##### Only if you are not using Cocoapods
 
-- Drag and drop the ios/ImageCropPickerSDK folder to your xcode project. (Make sure Copy items if needed IS ticked)
 - Click on project General tab
   - Under `Deployment Info` set `Deployment Target` to `8.0`
   - Under `Embedded Binaries` click `+` and add `RSKImageCropper.framework` and `QBImagePicker.framework`


### PR DESCRIPTION
I verified that this step ("drop the ios/ImageCropPickerSDK folder to your xcode project") is not required using Xcode 9.4.1, iOS 11.4 and React Native 0.55.4 when doing a manual install.

Adding the ImageCropPickerSDK folder would also trigger the "CFBundleIdentifier Collision" error on TestFlight as reported in issue #61.