### PR TITLE
Fix the API level 19 condition

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -17,10 +17,10 @@ import java.io.InputStream;
 class RealPathUtil {
     static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
 
-        final boolean isKitKat = Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT;
+        final boolean isKitKatOrGreater = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
         // DocumentProvider
-        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+        if (isKitKatOrGreater && DocumentsContract.isDocumentUri(context, uri)) {
             // ExternalStorageProvider
             if (isExternalStorageDocument(uri)) {
                 final String docId = DocumentsContract.getDocumentId(uri);


### PR DESCRIPTION
Initially, the condition was

```java
final boolean isKitKat = Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT;
```

which was changed to

```java
final boolean isKitKat = Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT;
```

in https://github.com/ivpusic/react-native-image-crop-picker/commit/88a03f54e349d78391d5b6444ab5f45bccabf5c3.

The condition is to check if we can use `DocumentsContract` which was added in API level 19 which can be verified at https://developer.android.com/reference/android/provider/DocumentsContract. So, I think the correct condition should be

```java
final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
```

Otherwise, I don't think we need all that code present under that condition just to handle API level 19 or Kit Kat.