### PR TITLE
Avoid conflicts with other SDKs that are using FileProvider

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application>
 
         <provider
-            android:name="android.support.v4.content.FileProvider"
+            android:name=".CropFileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/CropFileProvider.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/CropFileProvider.java
@@ -1,0 +1,12 @@
+package com.reactnative.ivpusic.imagepicker;
+
+import android.support.v4.content.FileProvider;
+
+/**
+ * Providing a custom {@code FileProvider} prevents manifest {@code <provider>} name collisions.
+ *
+ * See https://developer.android.com/guide/topics/manifest/provider-element.html for details.
+ */
+public class CropFileProvider extends FileProvider {
+    // This class intentionally left blank.
+}


### PR DESCRIPTION
I had a conflict with another SDK: https://github.com/kinecosystem/kin-ecosystem-android-sdk/issues/175

solution found here: 
https://github.com/stkent/bugshaker-android/issues/108#issuecomment-293291649
