### PR TITLE
Added missing flags to support front camera on some android phones

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -309,6 +309,8 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
             if (this.useFrontCamera) {
                 cameraIntent.putExtra("android.intent.extras.CAMERA_FACING", 1);
+                cameraIntent.putExtra("android.intent.extras.LENS_FACING_FRONT", 1);
+                cameraIntent.putExtra("android.intent.extra.USE_FRONT_CAMERA", true);
             }
 
             if (cameraIntent.resolveActivity(activity.getPackageManager()) == null) {


### PR DESCRIPTION
I did some searching and there are different flags for different phones, in my case previous flag for Android was not working with a Google Pixel phone, Im adding 2 new flags tu support more android phones