### PR TITLE
Update RealPathUtil.java

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 class RealPathUtil {
     static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
 
-        final boolean isKitKat = Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT;
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
         // DocumentProvider
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {


### PR DESCRIPTION
Hi,

This package is great and I use it frequently,

This is an update to getRealPathFromURI to work for Kitkat api and above instead of just Kitkat, so that for more advanced versions, there would be no need for cache.

Best Regards