### PR TITLE
Fixed Error "Configuration 'compile' is obsolete"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.github.yalantis:ucrop:2.2.2-native'
-    compile 'id.zelory:compressor:2.1.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.github.yalantis:ucrop:2.2.2-native'
+    implementation 'id.zelory:compressor:2.1.0'
 }


### PR DESCRIPTION
Fixed Android Studio Error "Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'. It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html"