### PR TITLE
Remove WRITE_EXTERNAL_STORAGE permission check for internal storage access

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -154,30 +154,22 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     public void clean(final Promise promise) {
 
         final Activity activity = getCurrentActivity();
-        final PickerModule module = this;
 
         if (activity == null) {
             promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "Activity doesn't exist");
             return;
         }
 
-        permissionsCheck(activity, promise, Collections.singletonList(Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
-            @Override
-            public Void call() {
-                try {
-                    File file = new File(module.getTmpDir(activity));
-                    if (!file.exists()) throw new Exception("File does not exist");
+        try {
+            File file = new File(getTmpDir(activity));
+            if (!file.exists()) throw new Exception("File does not exist");
 
-                    module.deleteRecursive(file);
-                    promise.resolve(null);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                    promise.reject(E_ERROR_WHILE_CLEANING_FILES, ex.getMessage());
-                }
-
-                return null;
-            }
-        });
+            deleteRecursive(file);
+            promise.resolve(null);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            promise.reject(E_ERROR_WHILE_CLEANING_FILES, ex.getMessage());
+        }
     }
 
     @ReactMethod
@@ -285,7 +277,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         setConfiguration(options);
         resultCollector.setup(promise, false);
 
-        permissionsCheck(activity, promise, Arrays.asList(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
+        permissionsCheck(activity, promise, Collections.singletonList(Manifest.permission.CAMERA), new Callable<Void>() {
             @Override
             public Void call() {
                 initiateCamera(activity);
@@ -302,10 +294,10 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
             if (mediaType.equals("video")) {
                 intent = MediaStore.ACTION_VIDEO_CAPTURE;
-                dataFile = createVideoFile();
+                dataFile = createVideoFile(activity);
             } else {
                 intent = MediaStore.ACTION_IMAGE_CAPTURE;
-                dataFile = createImageFile();
+                dataFile = createImageFile(activity);
             }
 
             Intent cameraIntent = new Intent(intent);
@@ -375,13 +367,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         setConfiguration(options);
         resultCollector.setup(promise, multiple);
 
-        permissionsCheck(activity, promise, Collections.singletonList(Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
-            @Override
-            public Void call() {
-                initiatePicker(activity);
-                return null;
-            }
-        });
+        initiatePicker(activity);
     }
 
     @ReactMethod
@@ -774,15 +760,24 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                 || activity.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY);
     }
 
-    private File createImageFile() throws IOException {
-
-        String imageFileName = "image-" + UUID.randomUUID().toString();
-        File path = Environment.getExternalStoragePublicDirectory(
-                Environment.DIRECTORY_PICTURES);
-
+    private File getCameraOutputDir(Activity activity) {
+        int status = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        File path;
+        if (status == PackageManager.PERMISSION_GRANTED) {
+            path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        } else {
+            path = new File(getTmpDir(activity), "camera");
+        }
         if (!path.exists() && !path.isDirectory()) {
             path.mkdirs();
         }
+        return path;
+    }
+
+    private File createImageFile(Activity activity) throws IOException {
+
+        String imageFileName = "image-" + UUID.randomUUID().toString();
+        File path = getCameraOutputDir(activity);
 
         File image = File.createTempFile(imageFileName, ".jpg", path);
 
@@ -793,15 +788,10 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     }
 
-    private File createVideoFile() throws IOException {
+    private File createVideoFile(Activity activity) throws IOException {
 
         String videoFileName = "video-" + UUID.randomUUID().toString();
-        File path = Environment.getExternalStoragePublicDirectory(
-                Environment.DIRECTORY_PICTURES);
-
-        if (!path.exists() && !path.isDirectory()) {
-            path.mkdirs();
-        }
+        File path = getCameraOutputDir(activity);
 
         File video = File.createTempFile(videoFileName, ".mp4", path);
 


### PR DESCRIPTION
This pull request removes the need of the _WRITE_EXTERNAL_STORAGE_ permission for most of this module's methods on Android. As most of the functions only work with the app's internal storage, they do not need any additional permission. This addresses the issue #905.

Overview of the changes:
- The _clean_ and _openPicker_ methods does no longer check for the _WRITE_EXTERNAL_STORAGE_ permission as it only clears a folder from the internal cache
- The _openCamera_ method does no longer require the _WRITE_EXTERNAL_STORAGE_ permission. If this permission is granted, photos and videos taken will be stored to the external storage as they have been until now. Otherwise, they will be temporarily stored in the app's internal cache storage (optional behavior).