### PR TITLE
Fix Android image rotation issue when compressing gallery and camera …

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -3,6 +3,8 @@ package com.reactnative.ivpusic.imagepicker;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+import android.media.ExifInterface;
 import android.os.Environment;
 import android.util.Log;
 
@@ -30,6 +32,14 @@ class Compression {
         int width = original.getWidth();
         int height = original.getHeight();
 
+        // Use original image exif orientation data to preserve image orientation for the resized bitmap
+        ExifInterface originalExif = new ExifInterface(originalImagePath);
+        int originalOrientation = originalExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
+
+        Matrix rotationMatrix = new Matrix();
+        int rotationAngleInDegrees = getRotationInDegreesForOrientationTag(originalOrientation);
+        rotationMatrix.postRotate(rotationAngleInDegrees);
+
         float ratioBitmap = (float) width / (float) height;
         float ratioMax = (float) maxWidth / (float) maxHeight;
 
@@ -43,6 +53,7 @@ class Compression {
         }
 
         Bitmap resized = Bitmap.createScaledBitmap(original, finalWidth, finalHeight, true);
+        resized = Bitmap.createBitmap(resized, 0, 0, finalWidth, finalHeight, rotationMatrix, true);
         File resizeImageFile = new File(Environment.getExternalStoragePublicDirectory(
                 Environment.DIRECTORY_PICTURES), UUID.randomUUID() + ".jpg");
 
@@ -54,6 +65,19 @@ class Compression {
         resized.recycle();
 
         return resizeImageFile;
+    }
+
+    int getRotationInDegreesForOrientationTag(int orientationTag) {
+        switch(orientationTag){
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                return 90;
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                return -90;
+            case ExifInterface.ORIENTATION_ROTATE_180:
+                return 180;
+            default:
+                return 0;
+        }
     }
 
     File compressImage(final ReadableMap options, final String originalImagePath, final BitmapFactory.Options bitmapOptions) throws IOException {


### PR DESCRIPTION
## Motivation
When using the image compression options on Android, the orientation of the resized image differed from the original image. This caused selected images to often be rotated. This change rotates the compressed image according to the exif orientation tag of the original image file.

This change provides a solution for issue #379.
