### PR TITLE
Intent change due to error in image load

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -347,6 +347,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                             MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
             libraryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple);
             activity.startActivityForResult(libraryIntent, IMAGE_PICKER_REQUEST);
+            return;
             } else if (mediaType.equals("video")) {
                 galleryIntent.setType("video/*");
             } else {


### PR DESCRIPTION
Images could not be loaded on selection due to the following error 
error code "E_NO_IMAGE_DATA_FOUND" .
 Intent has been changed in android to rectify the issue