### PR TITLE
[Android] autoclose inputstream when base64 image file

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -401,30 +401,29 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private String getBase64StringFromFile(String absoluteFilePath) {
-        InputStream inputStream;
+        try (
+                InputStream inputStream = new FileInputStream(new File(absoluteFilePath));
+                ByteArrayOutputStream output = new ByteArrayOutputStream()
+        ) {
+            byte[] bytes;
+            byte[] buffer = new byte[8192];
+            int bytesRead;
 
-        try {
-            inputStream = new FileInputStream(new File(absoluteFilePath));
-        } catch (FileNotFoundException e) {
+            try {
+                while ((bytesRead = inputStream.read(buffer)) != -1) {
+                    output.write(buffer, 0, bytesRead);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            bytes = output.toByteArray();
+            return Base64.encodeToString(bytes, Base64.NO_WRAP);
+        } catch (IOException e) {
             e.printStackTrace();
             return null;
         }
 
-        byte[] bytes;
-        byte[] buffer = new byte[8192];
-        int bytesRead;
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-
-        try {
-            while ((bytesRead = inputStream.read(buffer)) != -1) {
-                output.write(buffer, 0, bytesRead);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        bytes = output.toByteArray();
-        return Base64.encodeToString(bytes, Base64.NO_WRAP);
     }
 
     private String getMimeType(String url) {


### PR DESCRIPTION
The inputstream not close when base64 image file:
> com.reactnative.ivpusic.imagepicker.PickerModule#getBase64StringFromFile

This will case app exist by the exception:
```
D/StrictMode: StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
        at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1803)
        at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:264)
        at java.io.FileInputStream.finalize(FileInputStream.java:487)
        at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:250)
        at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:237)
        at java.lang.Daemons$Daemon.run(Daemons.java:103)
        at java.lang.Thread.run(Thread.java:784)
     Caused by: java.lang.Throwable: Explicit termination method 'close' not called
        at dalvik.system.CloseGuard.open(CloseGuard.java:221)
        at java.io.FileInputStream.<init>(FileInputStream.java:168)
        at com.reactnative.ivpusic.imagepicker.PickerModule.getBase64StringFromFile(PickerModule.java:407)
        at com.reactnative.ivpusic.imagepicker.PickerModule.getImage(PickerModule.java:584)
        at com.reactnative.ivpusic.imagepicker.PickerModule.getAsyncSelection(PickerModule.java:474)
        at com.reactnative.ivpusic.imagepicker.PickerModule.imagePickerResult(PickerModule.java:663)
        at com.reactnative.ivpusic.imagepicker.PickerModule.onActivityResult(PickerModule.java:760)
        at com.facebook.react.bridge.ReactContext.onActivityResult(ReactContext.java:255)
        at com.facebook.react.ReactInstanceManager.onActivityResult(ReactInstanceManager.java:706)
        at com.facebook.react.ReactActivityDelegate.onActivityResult(ReactActivityDelegate.java:126)
        at com.facebook.react.ReactActivity.onActivityResult(ReactActivity.java:77)
        at android.app.Activity.dispatchActivityResult(Activity.java:7797)
        at android.app.ActivityThread.deliverResults(ActivityThread.java:5044)
        at android.app.ActivityThread.handleSendResult(ActivityThread.java:5093)
        at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:49)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2185)
        at android.os.Handler.dispatchMessage(Handler.java:112)
        at android.os.Looper.loop(Looper.java:216)
        at android.app.ActivityThread.main(ActivityThread.java:7593)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:524)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987)
```