### PR TITLE
add creationDate support for video files

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -456,7 +456,14 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 
 - (void) handleVideo:(AVAsset*)asset withFileName:(NSString*)fileName withLocalIdentifier:(NSString*)localIdentifier completion:(void (^)(NSDictionary* image))completion {
     NSURL *sourceURL = [(AVURLAsset *)asset URL];
-
+    
+    // extract creation date
+    AVMetadataItem *creationDateMeta = asset.creationDate;
+    NSDate *creationDate;
+    if (creationDateMeta) {
+        creationDate = creationDateMeta.dateValue;
+    }
+    
     // create temp file
     NSString *tmpDirFullPath = [self getTmpDirectory];
     NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
@@ -484,7 +491,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                              withSize:fileSizeValue
                                              withData:nil
                                              withRect:CGRectNull
-                                     withCreationDate:nil
+                                     withCreationDate:creationDate
                                  withModificationDate:nil
                         ]);
         } else {


### PR DESCRIPTION
Currently it's impossible to get `creationDate` property when picking video on iOS device.