### PR TITLE
Fixing multiple file provider issue

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application>
 
         <provider
-            android:name="android.support.v4.content.FileProvider"
+            android:name=".FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">
@@ -17,7 +17,6 @@
 
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
     </application>
 

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/FileProvider.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/FileProvider.java
@@ -1,0 +1,10 @@
+package com.reactnative.ivpusic.imagepicker;
+
+/**
+ * Providing a custom <code>FileProvider</code> prevents manifest <code>&lt;provider&gt;</code> name collisions.
+ */
+public class FileProvider extends android.support.v4.content.FileProvider {
+
+    // This class intentionally left blank.
+
+}


### PR DESCRIPTION
I was using `react-native-image-crop-picker` in my project. In this project, the file provider is mentioned in the `AndroidManifest.xml` of the library itself.

In my project, I am using another library (`react-native-freshchat`) which also needs FileProvider.  Freshchat(or in future may be another library) requires the provider to be added in the application's `AndroidManifest.xml`. 

Because of multiple FileProviders, the build compilation was throwing an error and asking me to override the configuration in the application's `AndroidManifest.xml` using tools. I tried the same and compilation went fine but my `react-native-image-picker` openCamera stopped working.

So, this pull request takes care of such scenarios where we just extend the base FileProvider class. This is inspired by https://github.com/stkent/bugshaker-android/commit/5155a80f73406c4c3773a3e6873658b5c82a363b