### PR TITLE
Add compressImageMaxPixels feature, unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ local.properties
 #
 node_modules/
 npm-debug.log
+package-lock.json
 
 # BUCK
 buck-out/

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ImagePicker.openPicker({
 **Android: The prop 'cropping' has been known to cause videos not to be display in the gallery on Android. Please do not set cropping to true when selecting videos.**
 
 
-### Select from camera 
+### Select from camera
 
 #### Image
 
@@ -131,6 +131,7 @@ ImagePicker.clean().then(() => {
 | smartAlbums (ios only)                  | array ([supported values](https://github.com/ivpusic/react-native-image-crop-picker/blob/master/README.md#smart-album-types-ios)) (default ['UserLibrary', 'PhotoStream', 'Panoramas', 'Videos', 'Bursts']) | List of smart albums to choose from      |
 | useFrontCamera                          |           bool (default false)           | Whether to default to the front/'selfie' camera when opened |
 | compressVideoPreset (ios only)          |      string (default MediumQuality)      | Choose which preset will be used for video compression |
+| compressImageMaxPixels                  |          number (default none)           | Compress image to maximum total number of pixels.  If this is present and > 0, compressImageMaxWidth and compressImageMaxHeight is ignored.|
 | compressImageMaxWidth                   |          number (default none)           | Compress image with maximum width        |
 | compressImageMaxHeight                  |          number (default none)           | Compress image with maximum height       |
 | compressImageQuality                    |            number (default 1 (Android)/0.8 (iOS))            | Compress image with quality (from 0 to 1, where 1 is best quality). On iOS, values larger than 0.8 don't produce a noticable quality increase in most images, while a value of 0.8 will reduce the file size by about half or less compared to a value of 1. |
@@ -214,7 +215,7 @@ target '<project_name>' do
   pod 'RNImageCropPicker', :path =>  '../node_modules/react-native-image-crop-picker'
 end
 
-# very important to have, unless you removed React dependencies for Libraries 
+# very important to have, unless you removed React dependencies for Libraries
 # and you rely on Cocoapods to manage it
 post_install do |installer|
   installer.pods_project.targets.each do |target|
@@ -260,12 +261,12 @@ In Xcode open Info.plist and add string key `NSPhotoLibraryUsageDescription` wit
 - Click on project General tab
   - Under `Deployment Info` set `Deployment Target` to `8.0`
   - Under `Embedded Binaries` click `+` and add `RSKImageCropper.framework` and `QBImagePicker.framework`
-  
+
 #### Step Optional - To localizate the camera / gallery text buttons
 
 - Open your Xcode project
 - Go to your project settings by opening the project name on the Navigation (left side)
-- Select your project in the project list 
+- Select your project in the project list
 - Should be into the Info tab and add in Localizations the language your app was missing throughout the +
 - Rebuild and you should now have your app camera and gallery with the classic ios text in the language you added.
 
@@ -324,7 +325,7 @@ android {
     compileSdkVersion 27
     buildToolsVersion "27.0.3"
     ...
-    
+
     defaultConfig {
       ...
       targetSdkVersion 27
@@ -370,6 +371,40 @@ Details for second approach:
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
 <a href="graphs/contributors"><img src="https://opencollective.com/react-native-image-crop-picker/contributors.svg?width=890" /></a>
+
+## Development
+
+## Android
+
+Android's build gradle can refer to the installation of react-native in the root `node_modules` directory,
+by way of the  `devDependency` in the top-level `package.json`.
+
+## iOS
+
+To build the imageCropPicker target, "react-native" must be installed on the same folder, e.g. alongside
+
+the react-native-image-crop-picker folder. TODO: update xcode to be able to use the react-native `devDependency` installation.
+
+### package.json
+
+The project has a react-native as a peerDependency, but also in its devDependencies, for local tests.
+
+### Android Studio Unit Testing
+
+Tests are implemented as standard JUnit tests.  No additional setup is required.
+
+### XCode Unit Testing
+
+Unit tests exist in the example app (in the example directory).  There is a exampleTests target.
+1. Install dependencies for the example app.
+```
+cd example
+npm i
+cd ios && pod install
+```
+2. Open the example.xcworkspace project.
+3. Go to the Test Navigator
+4. Select the tests to run (e.g. scaleTests)
 
 
 ## Backers

--- a/android/android.iml
+++ b/android/android.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -9,7 +9,6 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <afterSyncTasks>
@@ -18,35 +17,36 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res;file://$MODULE_DIR$/build/generated/res/resValues/debug" />
+        <option name="TEST_RES_FOLDERS_RELATIVE_PATH" value="" />
         <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
-        <option name="LIBRARY_PROJECT" value="true" />
+        <option name="PROJECT_TYPE" value="1" />
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
+    <output url="file://$MODULE_DIR$/build/intermediates/javac/debug/compileDebugJavaWithJavac/classes" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/javac/debugUnitTest/compileDebugUnitTestJavaWithJavac/classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/aidl_source_output_dir/debug/compileDebugAidl/out" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/renderscript_source_output_dir/debug/compileDebugRenderscript/out" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/aidl_source_output_dir/debugAndroidTest/compileDebugAndroidTestAidl/out" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/renderscript_source_output_dir/debugAndroidTest/compileDebugAndroidTestRenderscript/out" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
@@ -54,15 +54,20 @@
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
@@ -70,7 +75,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
@@ -78,66 +82,83 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/23.3.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.3.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.3.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.3.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/drawee/0.8.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/fbcore/0.8.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/fresco/0.8.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/imagepipeline-okhttp/0.8.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/imagepipeline/0.8.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.react/react-native/0.20.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.yalantis/ucrop/1.5.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/org.webkit/android-jsc/r174650/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/generated/not_namespaced_r_class_sources" />
+      <excludeFolder url="file://$MODULE_DIR$/build/generated/source/r" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/aapt_friendly_merged_manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotation_processor_list" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check_manifest_result" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/compile_only_not_namespaced_r_class_jar" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javac" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/library_manifest" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/merged_manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/packaged_res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/public_res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="jdk" jdkName="Android API 28 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="okhttp-ws-2.5.0" level="project" />
-    <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
-    <orderEntry type="library" exported="" name="okhttp-2.5.0" level="project" />
-    <orderEntry type="library" exported="" name="stetho-1.2.0" level="project" />
-    <orderEntry type="library" exported="" name="jsr305-3.0.0" level="project" />
-    <orderEntry type="library" exported="" name="fbcore-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="commons-cli-1.2" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-23.0.1" level="project" />
-    <orderEntry type="library" exported="" name="imagepipeline-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="android-jsc-r174650" level="project" />
-    <orderEntry type="library" exported="" name="fresco-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-23.3.0" level="project" />
-    <orderEntry type="library" exported="" name="imagepipeline-okhttp-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="bolts-android-1.1.4" level="project" />
-    <orderEntry type="library" exported="" name="drawee-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-23.3.0" level="project" />
-    <orderEntry type="library" exported="" name="support-vector-drawable-23.3.0" level="project" />
-    <orderEntry type="library" exported="" name="animated-vector-drawable-23.3.0" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-23.3.0" level="project" />
-    <orderEntry type="library" exported="" name="library-2.4.0" level="project" />
-    <orderEntry type="library" exported="" name="stetho-okhttp-1.2.0" level="project" />
-    <orderEntry type="library" exported="" name="ucrop-1.5.0" level="project" />
-    <orderEntry type="library" exported="" name="jackson-core-2.2.3" level="project" />
-    <orderEntry type="library" exported="" name="okhttp-3.2.0" level="project" />
-    <orderEntry type="library" exported="" name="react-native-0.20.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp-urlconnection:3.12.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.fresco:fresco:1.10.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-fragment:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:localbroadcastmanager:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.fresco:fbcore:1.10.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:animated-vector-drawable:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.fresco:drawee:1.10.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:viewmodel:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.12.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:loader:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.core:runtime:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata-core:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:cursoradapter:28.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.powermock:powermock-reflect:1.6.4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:runtime:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-compat:28.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.powermock:powermock-api-support:1.6.4@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.powermock:powermock-api-mockito:1.6.4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.fresco:imagepipeline-base:1.10.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: javax.inject:javax.inject:1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.soloader:soloader:0.6.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.powermock:powermock-core:1.6.4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.code.findbugs:jsr305:3.0.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-utils:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-vector-drawable:28.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.javassist:javassist:3.20.0-GA@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-annotations:28.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:interpolator:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata:1.1.1@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.powermock:powermock-module-junit4:1.6.4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.yalantis:ucrop:2.2.2-native@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:drawerlayout:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:documentfile:28.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.mockito:mockito-core:1.10.19@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:slidingpanelayout:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:appcompat-v7:28.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.powermock:powermock-module-junit4-common:1.6.4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.react:react-native:0.59.10@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.objenesis:objenesis:2.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:collections:28.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-ui:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.fresco:imagepipeline-okhttp3:1.10.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:asynclayoutinflater:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:print:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.core:common:1.1.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:versionedparcelable:28.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.infer.annotation:infer-annotation:0.11.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.facebook.fresco:imagepipeline:1.10.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:viewpager:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:common:1.1.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:coordinatorlayout:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:customview:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:swiperefreshlayout:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.15.0@jar" level="project" />
   </component>
 </module>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,14 +5,40 @@ def DEFAULT_BUILD_TOOLS_VERSION   = "28.0.3"
 def DEFAULT_TARGET_SDK_VERSION    = 28
 def DEFAULT_MIN_SDK_VERSION       = 16
 
-android {
-        compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-        buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+def RN_DEPENDENCY_PATH = "$rootDir/../node_modules/react-native";
 
-  defaultConfig {
+ext.getReactNativeVersion = { ->
+    try {
+        def jsonFile = file(RN_DEPENDENCY_PATH + '/package.json')
+        def parsedJson = new groovy.json.JsonSlurper().parseText(jsonFile.text)
+        return parsedJson.version;
+    } catch (e) {
+        logger.warn("Unable to determing react-native version, using + (latest)");
+        return "+";
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+        maven { url "https://jitpack.io" }
+        google()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url RN_DEPENDENCY_PATH + "/android"
+        }
+    }
+}
+
+android {
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+
+    defaultConfig {
         minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         abortOnError false
@@ -20,6 +46,21 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:' + getReactNativeVersion()
     implementation 'com.github.yalantis:ucrop:2.2.2-native'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.4'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.4'
+}
+
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.4.2'
+    }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,3 @@
+include ':testlib'
+
+

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -26,12 +26,7 @@ import java.util.UUID;
 
 class Compression {
 
-    File resize(String originalImagePath, int maxWidth, int maxHeight, int quality) throws IOException {
-        Bitmap original = BitmapFactory.decodeFile(originalImagePath);
-
-        int width = original.getWidth();
-        int height = original.getHeight();
-
+    private Matrix getRotatedMatrix(String originalImagePath) throws IOException {
         // Use original image exif orientation data to preserve image orientation for the resized bitmap
         ExifInterface originalExif = new ExifInterface(originalImagePath);
         int originalOrientation = originalExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
@@ -39,21 +34,30 @@ class Compression {
         Matrix rotationMatrix = new Matrix();
         int rotationAngleInDegrees = getRotationInDegreesForOrientationTag(originalOrientation);
         rotationMatrix.postRotate(rotationAngleInDegrees);
+        return rotationMatrix;
+    }
 
-        float ratioBitmap = (float) width / (float) height;
-        float ratioMax = (float) maxWidth / (float) maxHeight;
+    File resize(String originalImagePath, int maxWidth, int maxHeight, int quality) throws IOException {
+       return resize(originalImagePath, maxWidth, maxHeight, quality, 0);
+    }
 
-        int finalWidth = maxWidth;
-        int finalHeight = maxHeight;
+    File resize(String originalImagePath, int maxWidth, int maxHeight, int quality, int maxPixels) throws IOException {
+        Bitmap original = BitmapFactory.decodeFile(originalImagePath);
 
-        if (ratioMax > 1) {
-            finalWidth = (int) ((float) maxHeight * ratioBitmap);
-        } else {
-            finalHeight = (int) ((float) maxWidth / ratioBitmap);
-        }
+        int width = original.getWidth();
+        int height = original.getHeight();
 
-        Bitmap resized = Bitmap.createScaledBitmap(original, finalWidth, finalHeight, true);
-        resized = Bitmap.createBitmap(resized, 0, 0, finalWidth, finalHeight, rotationMatrix, true);
+        Matrix rotationMatrix = getRotatedMatrix(originalImagePath);
+
+        Log.d("image-crop-picker", "Args: maxWidth: " + maxWidth + ", maxHeight: " + maxHeight + ", maxPixels: " + maxPixels);
+
+        Scale.Dimension finalDimensions = maxPixels > 0 ? Scale.getScaledImageDimensionsByMaxPixels(width, height, maxPixels) : Scale.getScaledImageDimensionsByMaxWidthHeight(width, height, maxWidth, maxHeight);
+
+        Log.d("image-crop-picker", "Final Dimensions: w: " + finalDimensions.getWidth() + ", h: " + finalDimensions.getHeight());
+
+
+        Bitmap resized = Bitmap.createScaledBitmap(original, finalDimensions.getWidth(), finalDimensions.getHeight(), true);
+        resized = Bitmap.createBitmap(resized, 0, 0, finalDimensions.getWidth(), finalDimensions.getHeight(), rotationMatrix, true);
         
         File imageDirectory = Environment.getExternalStoragePublicDirectory(
                 Environment.DIRECTORY_PICTURES);
@@ -88,19 +92,28 @@ class Compression {
         }
     }
 
-    File compressImage(final ReadableMap options, final String originalImagePath, final BitmapFactory.Options bitmapOptions) throws IOException {
-        Integer maxWidth = options.hasKey("compressImageMaxWidth") ? options.getInt("compressImageMaxWidth") : null;
-        Integer maxHeight = options.hasKey("compressImageMaxHeight") ? options.getInt("compressImageMaxHeight") : null;
-        Double quality = options.hasKey("compressImageQuality") ? options.getDouble("compressImageQuality") : null;
-
+    boolean shouldCompress(BitmapFactory.Options bitmapOptions, Double quality, Integer maxWidth, Integer maxHeight, Integer maxPixels) {
         boolean isLossLess = (quality == null || quality == 1.0);
         boolean useOriginalWidth = (maxWidth == null || maxWidth >= bitmapOptions.outWidth);
         boolean useOriginalHeight = (maxHeight == null || maxHeight >= bitmapOptions.outHeight);
 
+        Integer currentPixels = bitmapOptions.outWidth * bitmapOptions.outHeight;
+        boolean isPreserveDimensions =  maxPixels == 0 ?  (useOriginalWidth && useOriginalHeight) : (maxPixels >= currentPixels);
+
+
         List knownMimes = Arrays.asList("image/jpeg", "image/jpg", "image/png", "image/gif", "image/tiff");
         boolean isKnownMimeType = (bitmapOptions.outMimeType != null && knownMimes.contains(bitmapOptions.outMimeType.toLowerCase()));
 
-        if (isLossLess && useOriginalWidth && useOriginalHeight && isKnownMimeType) {
+        return !(isLossLess && isPreserveDimensions && isKnownMimeType);
+    }
+
+    File compressImage(final ReadableMap options, final String originalImagePath, final BitmapFactory.Options bitmapOptions) throws IOException {
+        Integer maxWidth = options.hasKey("compressImageMaxWidth") ? options.getInt("compressImageMaxWidth") : null;
+        Integer maxHeight = options.hasKey("compressImageMaxHeight") ? options.getInt("compressImageMaxHeight") : null;
+        Integer maxPixels = options.hasKey("compressImageMaxPixels") ? options.getInt("compressImageMaxPixels") : 0;
+        Double quality = options.hasKey("compressImageQuality") ? options.getDouble("compressImageQuality") : null;
+
+        if (!shouldCompress(bitmapOptions, quality, maxWidth, maxHeight, maxPixels)) {
             Log.d("image-crop-picker", "Skipping image compression");
             return new File(originalImagePath);
         }
@@ -123,7 +136,7 @@ class Compression {
             maxHeight = Math.min(maxHeight, bitmapOptions.outHeight);
         }
 
-        return resize(originalImagePath, maxWidth, maxHeight, targetQuality);
+        return resize(originalImagePath, maxWidth, maxHeight, targetQuality, maxPixels);
     }
 
     synchronized void compressVideo(final Activity activity, final ReadableMap options, final String originalVideo, final String compressedVideo, final Promise promise) {

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Scale.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Scale.java
@@ -1,0 +1,49 @@
+package com.reactnative.ivpusic.imagepicker;
+
+import android.util.Log;
+
+import java.math.BigDecimal;
+
+public class Scale {
+    public static class Dimension {
+        private int width;
+        private int height;
+        public Dimension(int width, int height) {
+            this.width = width;
+            this.height = height;
+        }
+        public int getWidth() {
+            return width;
+        }
+        public int getHeight() {
+            return height;
+        }
+    }
+
+    public static Dimension getScaledImageDimensionsByMaxWidthHeight(int width, int height, int maxWidth, int maxHeight) {
+        float ratioBitmap = (float) width / (float) height;
+        float ratioMax = (float) maxWidth / (float) maxHeight;
+
+        int finalWidth = maxWidth;
+        int finalHeight = maxHeight;
+
+        if (ratioMax > 1) {
+            finalWidth = (int) ((float) maxHeight * ratioBitmap);
+        } else {
+            finalHeight = (int) ((float) maxWidth / ratioBitmap);
+        }
+        return new Dimension(finalWidth, finalHeight);
+    }
+
+    public static Dimension getScaledImageDimensionsByMaxPixels(int width, int height, int maxPixels) {
+        int currentPixels = width * height;
+        double scale = 1.0;
+        if (currentPixels > maxPixels && currentPixels > 0 && maxPixels > 0) {
+            BigDecimal ratio = new BigDecimal(currentPixels).divide(new BigDecimal(maxPixels));
+            scale = scale / Math.sqrt(ratio.doubleValue());
+        }
+        Log.d("image-crop-picker", "Compression: currentPixels: " + currentPixels + ", maxPixels: " + maxPixels + ", scale: " + scale);
+        return new Dimension((int)(width * scale), (int)(height * scale));
+    }
+
+}

--- a/android/src/test/java/com/reactnative/ivpusic/imagepicker/CompressionTest.java
+++ b/android/src/test/java/com/reactnative/ivpusic/imagepicker/CompressionTest.java
@@ -1,0 +1,88 @@
+package com.reactnative.ivpusic.imagepicker;
+
+import android.graphics.BitmapFactory;
+import android.util.Log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Log.class)
+public class CompressionTest {
+
+    @Before
+    public void beforeTest() {
+        PowerMockito.mockStatic(Log.class);
+        Mockito.when(Log.d(anyString(), anyString())).thenReturn(0);
+    }
+
+    @Test
+    public void compressionTest_shouldCompress_returns_true_for_maxPixels_lt_currentPixels() {
+        Compression compression = new Compression();
+
+        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
+        bitmapOptions.outHeight = 3024;
+        bitmapOptions.outWidth = 4032;
+        bitmapOptions.outMimeType = "image/jpeg";
+
+        assertTrue(compression.shouldCompress(bitmapOptions, null, null, null, 4000000));
+    }
+
+    @Test
+    public void compressionTest_shouldNotCompress_returns_false_for_maxPixels_gt_currentPixels() {
+        Compression compression = new Compression();
+
+        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
+        bitmapOptions.outHeight = 768;
+        bitmapOptions.outWidth = 1024;
+        bitmapOptions.outMimeType = "image/jpeg";
+
+        assertFalse(compression.shouldCompress(bitmapOptions, null, null, null, 4000000));
+    }
+
+    @Test
+    public void compressionTest_shouldCompress_returns_true_for_maxWidth_lt_currentWidth() {
+        Compression compression = new Compression();
+
+        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
+        bitmapOptions.outHeight = 3024;
+        bitmapOptions.outWidth = 4032;
+        bitmapOptions.outMimeType = "image/jpeg";
+
+        assertTrue(compression.shouldCompress(bitmapOptions, null, 3000, null, 0));
+    }
+
+    @Test
+    public void compressionTest_shouldNotCompress_returns_false_for_maxWidth_gt_currentWidth() {
+        Compression compression = new Compression();
+
+        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
+        bitmapOptions.outHeight = 768;
+        bitmapOptions.outWidth = 1024;
+        bitmapOptions.outMimeType = "image/jpeg";
+
+        assertFalse(compression.shouldCompress(bitmapOptions, null, 2048, null, 0));
+    }
+
+    @Test
+    public void compressionTest_shouldCompress_returns_true_for_unknown_mime_type() {
+        Compression compression = new Compression();
+
+        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
+        bitmapOptions.outHeight = 768;
+        bitmapOptions.outWidth = 1024;
+        bitmapOptions.outMimeType = "image/nachos";
+
+        assertTrue(compression.shouldCompress(bitmapOptions, null, 3000, null, 0));
+    }
+}

--- a/android/src/test/java/com/reactnative/ivpusic/imagepicker/ScaleTest.java
+++ b/android/src/test/java/com/reactnative/ivpusic/imagepicker/ScaleTest.java
@@ -1,0 +1,49 @@
+package com.reactnative.ivpusic.imagepicker;
+
+import android.util.Log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Log.class)
+public class ScaleTest {
+
+    @Before
+    public void beforeTest() {
+        PowerMockito.mockStatic(Log.class);
+        Mockito.when(Log.d(anyString(), anyString())).thenReturn(0);
+    }
+
+    @Test
+    public void scaleTest_getScaledImageDimensionsByMaxWidthHeight_returns_correct_values() {
+        Scale.Dimension d = Scale.getScaledImageDimensionsByMaxWidthHeight(
+                4032,
+        3024,
+        2560,
+        2560
+        );
+        assertEquals(2560, d.getWidth());
+        assertEquals(1920, d.getHeight() );
+    }
+
+    @Test
+    public void scaleTest_getScaledImageDimensionsByMaxPixels_returns_correct_values() {
+        Scale.Dimension d = Scale.getScaledImageDimensionsByMaxPixels(
+                4032,
+                3024,
+                5000000
+        );
+        assertEquals(2581, d.getWidth());
+        assertEquals(1936, d.getHeight() );
+    }
+
+}

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -13,12 +13,18 @@ target 'example' do
     'RCTLinkingIOS',
     'RCTNetwork',
     'RCTSettings',
+    'RCTTest',
     'RCTText',
     'RCTVibration',
     'RCTWebSocket'
   ]
 
-  pod 'RNImageCropPicker', :path =>  '../..'
+  pod 'RNImageCropPicker', :path =>  '../../'
+
+
+  target 'exampleTests' do
+    inherit! :search_paths
+  end
 end
 
 post_install do |installer|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -20,6 +20,8 @@ PODS:
     - React/Core
   - React/RCTSettings (0.59.1):
     - React/Core
+  - React/RCTTest (0.59.1):
+    - React/Core
   - React/RCTText (0.59.1):
     - React/Core
   - React/RCTVibration (0.59.1):
@@ -28,11 +30,11 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
-  - RNImageCropPicker (0.23.0):
+  - RNImageCropPicker (0.24.1):
     - QBImagePickerController
     - React/Core
     - RSKImageCropper
-  - RSKImageCropper (2.2.1)
+  - RSKImageCropper (2.2.2)
   - yoga (0.59.1.React)
 
 DEPENDENCIES:
@@ -44,10 +46,11 @@ DEPENDENCIES:
   - React/RCTLinkingIOS (from `../node_modules/react-native`)
   - React/RCTNetwork (from `../node_modules/react-native`)
   - React/RCTSettings (from `../node_modules/react-native`)
+  - React/RCTTest (from `../node_modules/react-native`)
   - React/RCTText (from `../node_modules/react-native`)
   - React/RCTVibration (from `../node_modules/react-native`)
   - React/RCTWebSocket (from `../node_modules/react-native`)
-  - RNImageCropPicker (from `../..`)
+  - RNImageCropPicker (from `../../`)
   - yoga (from `../node_modules/react-native/ReactCommon/yoga/yoga.podspec`)
 
 SPEC REPOS:
@@ -59,17 +62,17 @@ EXTERNAL SOURCES:
   React:
     :path: "../node_modules/react-native"
   RNImageCropPicker:
-    :path: "../.."
+    :path: "../../"
   yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga/yoga.podspec"
 
 SPEC CHECKSUMS:
   QBImagePickerController: d54cf93db6decf26baf6ed3472f336ef35cae022
-  React: 1d605e098d69bdf08960787f3446f0a9dc2e2ccf
-  RNImageCropPicker: 32ca4b9fef4e1b7b85ba69494242122948117e06
-  RSKImageCropper: 98296ad26b41753f796b6898d015509598f13d97
-  yoga: 128daf064cacaede0c3bb27424b6b4c71052e6cd
+  React: 34a405ead72252839fdc4afc1f972a7ed984af84
+  RNImageCropPicker: 6134b66a3d5bc13e2895a97c630a4254006902b4
+  RSKImageCropper: 05e3b82a18da83ea3c2b7bffa7f2199a621d6802
+  yoga: 8fb47f180b19b0dadb285a09e4c74c8a41721d3a
 
-PODFILE CHECKSUM: 4471a980145b75efa0c908363a6ae6487e284263
+PODFILE CHECKSUM: 3622b4af57087c52823ecc9cf8b1f86d87fe2750
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.7.4

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		00C302E81ABCBA2D00DB3ED1 /* libRCTImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302C01ABCB91800DB3ED1 /* libRCTImage.a */; };
 		00C302E91ABCBA2D00DB3ED1 /* libRCTNetwork.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302DC1ABCB9D200DB3ED1 /* libRCTNetwork.a */; };
 		00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302E41ABCB9EE00DB3ED1 /* libRCTVibration.a */; };
-		0BEAEB9C9085E265682ECE17 /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8617F59F4B274D55749C296B /* libPods-example.a */; };
 		133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C398B91ACF4ADC00677621 /* libRCTLinking.a */; };
 		139105C61AF99C1200B5F7CC /* libRCTSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139105C11AF99BAD00B5F7CC /* libRCTSettings.a */; };
 		139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139FDEF41B06529B00C62182 /* libRCTWebSocket.a */; };
@@ -25,7 +24,11 @@
 		34A9DDBF1D7F43320012B1F5 /* RSKImageCropper.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 34A9DDB91D7F43220012B1F5 /* RSKImageCropper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		34F74E571E073501001D9901 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F74E351E0733E3001D9901 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		9274FB876177FF9BEE41BE44 /* libPods-exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D920125AC04FC375D26DA18 /* libPods-exampleTests.a */; };
 		C7358F2638924AE4ACDF2B3C /* libRCTVideo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B590311A8214ACA88447B83 /* libRCTVideo.a */; };
+		E4EAED5FCBDB5BF7475B4AB0 /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 237B0E5B1D50D157C4C3B021 /* libPods-example.a */; };
+		FA82286122DBAAEF00272B8A /* exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA82286022DBAAEF00272B8A /* exampleTests.m */; };
+		FA82289522DBAB2A00272B8A /* scaleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA82282322DBA69400272B8A /* scaleTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,20 +116,6 @@
 			remoteGlobalIDString = 3D3CD9321DE5FBEE00167DC4;
 			remoteInfo = "cxxreact-tvOS";
 		};
-		341DB0281E31716A009BFCB3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D3CD90B1DE5FBD600167DC4;
-			remoteInfo = jschelpers;
-		};
-		341DB02A1E31716A009BFCB3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3D3CD9181DE5FBD800167DC4;
-			remoteInfo = "jschelpers-tvOS";
-		};
 		341DB04D1E317316009BFCB3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CAE92B1397B64654977AE8E7 /* RCTVideo.xcodeproj */;
@@ -196,20 +185,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = EBF21BFA1FC4989A0052F4D5;
 			remoteInfo = "jsinspector-tvOS";
-		};
-		34ECC923204DF1E30053BBC0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9936F3131F5F2E4B0010BF04;
-			remoteInfo = privatedata;
-		};
-		34ECC925204DF1E30053BBC0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9936F32F1F5F2E5B0010BF04;
-			remoteInfo = "privatedata-tvOS";
 		};
 		34F74E341E0733E3001D9901 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -288,6 +263,41 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
+		FA82286322DBAAEF00272B8A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 13B07F861A680F5B00A75B9A;
+			remoteInfo = example;
+		};
+		FA82288C22DBAAEF00272B8A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EDEBC6D6214B3E7000DD5AC8;
+			remoteInfo = jsi;
+		};
+		FA82288E22DBAAEF00272B8A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EDEBC73B214B45A300DD5AC8;
+			remoteInfo = jsiexecutor;
+		};
+		FA82289022DBAAEF00272B8A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = ED296FB6214C9A0900B7C4FE;
+			remoteInfo = "jsi-tvOS";
+		};
+		FA82289222DBAAEF00272B8A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = ED296FEE214C9CF800B7C4FE;
+			remoteInfo = "jsiexecutor-tvOS";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -314,7 +324,6 @@
 		00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = "../node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj"; sourceTree = "<group>"; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* exampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = exampleTests.m; sourceTree = "<group>"; };
-		038E3B40AAC8B9602A0C72CB /* Pods-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.release.xcconfig"; path = "Pods/Target Support Files/Pods-example/Pods-example.release.xcconfig"; sourceTree = "<group>"; };
 		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
 		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -325,15 +334,23 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = example/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = example/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		237B0E5B1D50D157C4C3B021 /* libPods-example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		34A9DDB81D7F43220012B1F5 /* QBImagePicker.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = QBImagePicker.framework; sourceTree = "<group>"; };
 		34A9DDB91D7F43220012B1F5 /* RSKImageCropper.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RSKImageCropper.framework; sourceTree = "<group>"; };
 		34F74E2D1E0733E2001D9901 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
+		46239C94515094F8E8A62E27 /* Pods-exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-exampleTests.release.xcconfig"; path = "Target Support Files/Pods-exampleTests/Pods-exampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		5B590311A8214ACA88447B83 /* libRCTVideo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTVideo.a; sourceTree = "<group>"; };
-		5B98ADA044EF4A42F2813B5F /* Pods-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-example/Pods-example.debug.xcconfig"; sourceTree = "<group>"; };
+		66E59CFF4AE9E25448ABF530 /* Pods-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.debug.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.debug.xcconfig"; sourceTree = "<group>"; };
+		6D920125AC04FC375D26DA18 /* libPods-exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		758B4E6C3D257B386B89C375 /* Pods-exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-exampleTests.debug.xcconfig"; path = "Target Support Files/Pods-exampleTests/Pods-exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
-		8617F59F4B274D55749C296B /* libPods-example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B6754748A1929D5F492A5FEC /* Pods-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.release.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.release.xcconfig"; sourceTree = "<group>"; };
 		CAE92B1397B64654977AE8E7 /* RCTVideo.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTVideo.xcodeproj; path = "../node_modules/react-native-video/ios/RCTVideo.xcodeproj"; sourceTree = "<group>"; };
+		FA82282322DBA69400272B8A /* scaleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = scaleTests.m; sourceTree = "<group>"; };
+		FA82285E22DBAAEF00272B8A /* exampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = exampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA82286022DBAAEF00272B8A /* exampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = exampleTests.m; sourceTree = "<group>"; };
+		FA82286222DBAAEF00272B8A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -353,7 +370,15 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				C7358F2638924AE4ACDF2B3C /* libRCTVideo.a in Frameworks */,
-				0BEAEB9C9085E265682ECE17 /* libPods-example.a in Frameworks */,
+				E4EAED5FCBDB5BF7475B4AB0 /* libPods-example.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA82285B22DBAAEF00272B8A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9274FB876177FF9BEE41BE44 /* libPods-exampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -407,6 +432,7 @@
 			children = (
 				00E356F21AD99517003FC87E /* exampleTests.m */,
 				00E356F01AD99517003FC87E /* Supporting Files */,
+				FA82282322DBA69400272B8A /* scaleTests.m */,
 			);
 			path = exampleTests;
 			sourceTree = "<group>";
@@ -419,13 +445,13 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		05142F2C788EC6F36DABEFD9 /* Pods */ = {
+		030529DF759E681F5FBE907E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				5B98ADA044EF4A42F2813B5F /* Pods-example.debug.xcconfig */,
-				038E3B40AAC8B9602A0C72CB /* Pods-example.release.xcconfig */,
+				237B0E5B1D50D157C4C3B021 /* libPods-example.a */,
+				6D920125AC04FC375D26DA18 /* libPods-exampleTests.a */,
 			);
-			name = Pods;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		139105B71AF99BAD00B5F7CC /* Products */ = {
@@ -471,16 +497,16 @@
 				341DB0231E31716A009BFCB3 /* libyoga.a */,
 				341DB0251E31716A009BFCB3 /* libcxxreact.a */,
 				341DB0271E31716A009BFCB3 /* libcxxreact.a */,
-				341DB0291E31716A009BFCB3 /* libjschelpers.a */,
-				341DB02B1E31716A009BFCB3 /* libjschelpers.a */,
 				34ECC920204DF1E30053BBC0 /* libjsinspector.a */,
 				34ECC922204DF1E30053BBC0 /* libjsinspector-tvOS.a */,
 				34BCCE511F27B7F800DD551F /* libthird-party.a */,
 				34BCCE531F27B7F800DD551F /* libthird-party.a */,
 				34BCCE551F27B7F800DD551F /* libdouble-conversion.a */,
 				34BCCE571F27B7F800DD551F /* libdouble-conversion.a */,
-				34ECC924204DF1E30053BBC0 /* libprivatedata.a */,
-				34ECC926204DF1E30053BBC0 /* libprivatedata-tvOS.a */,
+				FA82288D22DBAAEF00272B8A /* libjsi.a */,
+				FA82288F22DBAAEF00272B8A /* libjsiexecutor.a */,
+				FA82289122DBAAEF00272B8A /* libjsi-tvOS.a */,
+				FA82289322DBAAEF00272B8A /* libjsiexecutor-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -518,14 +544,6 @@
 				34F74E371E0733E3001D9901 /* libRCTAnimation.a */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		3EB888A3E4C0A2B8E812B4B1 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				8617F59F4B274D55749C296B /* libPods-example.a */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		78C398B11ACF4ADC00677621 /* Products */ = {
@@ -572,10 +590,11 @@
 				13B07FAE1A68108700A75B9A /* example */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* exampleTests */,
+				FA82285F22DBAAEF00272B8A /* exampleTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				3468219D1F7BAED90093F7F5 /* Recovered References */,
-				05142F2C788EC6F36DABEFD9 /* Pods */,
-				3EB888A3E4C0A2B8E812B4B1 /* Frameworks */,
+				AADD49662CBAE22320F604C8 /* Pods */,
+				030529DF759E681F5FBE907E /* Frameworks */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -585,8 +604,29 @@
 			isa = PBXGroup;
 			children = (
 				13B07F961A680F5B00A75B9A /* example.app */,
+				FA82285E22DBAAEF00272B8A /* exampleTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		AADD49662CBAE22320F604C8 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				66E59CFF4AE9E25448ABF530 /* Pods-example.debug.xcconfig */,
+				B6754748A1929D5F492A5FEC /* Pods-example.release.xcconfig */,
+				758B4E6C3D257B386B89C375 /* Pods-exampleTests.debug.xcconfig */,
+				46239C94515094F8E8A62E27 /* Pods-exampleTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		FA82285F22DBAAEF00272B8A /* exampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				FA82286022DBAAEF00272B8A /* exampleTests.m */,
+				FA82286222DBAAEF00272B8A /* Info.plist */,
+			);
+			path = exampleTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -596,13 +636,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "example" */;
 			buildPhases = (
-				DAF711D8831E8B798A174A11 /* [CP] Check Pods Manifest.lock */,
+				6A139BE2D1181D408FA49B08 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				340AECD21D799C3D009F3A60 /* Embed Frameworks */,
-				39B130511F44D996A17764D3 /* [CP] Copy Pods Resources */,
+				4F7C919802AEC80F309618A2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -612,6 +652,25 @@
 			productName = "Hello World";
 			productReference = 13B07F961A680F5B00A75B9A /* example.app */;
 			productType = "com.apple.product-type.application";
+		};
+		FA82285D22DBAAEF00272B8A /* exampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA82289422DBAAEF00272B8A /* Build configuration list for PBXNativeTarget "exampleTests" */;
+			buildPhases = (
+				3EB547D68CAFD3BC6C4BB928 /* [CP] Check Pods Manifest.lock */,
+				FA82285A22DBAAEF00272B8A /* Sources */,
+				FA82285B22DBAAEF00272B8A /* Frameworks */,
+				FA82285C22DBAAEF00272B8A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FA82286422DBAAEF00272B8A /* PBXTargetDependency */,
+			);
+			name = exampleTests;
+			productName = exampleTests;
+			productReference = FA82285E22DBAAEF00272B8A /* exampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -625,6 +684,11 @@
 					13B07F861A680F5B00A75B9A = {
 						DevelopmentTeam = 5WFBC66J2G;
 					};
+					FA82285D22DBAAEF00272B8A = {
+						CreatedOnToolsVersion = 10.2.1;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 13B07F861A680F5B00A75B9A;
+					};
 				};
 			};
 			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "example" */;
@@ -632,6 +696,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -691,6 +756,7 @@
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* example */,
+				FA82285D22DBAAEF00272B8A /* exampleTests */,
 			);
 		};
 /* End PBXProject section */
@@ -780,20 +846,6 @@
 			remoteRef = 341DB0261E31716A009BFCB3 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		341DB0291E31716A009BFCB3 /* libjschelpers.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libjschelpers.a;
-			remoteRef = 341DB0281E31716A009BFCB3 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		341DB02B1E31716A009BFCB3 /* libjschelpers.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libjschelpers.a;
-			remoteRef = 341DB02A1E31716A009BFCB3 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		341DB04E1E317316009BFCB3 /* libRCTVideo.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -862,20 +914,6 @@
 			fileType = archive.ar;
 			path = "libjsinspector-tvOS.a";
 			remoteRef = 34ECC921204DF1E30053BBC0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		34ECC924204DF1E30053BBC0 /* libprivatedata.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libprivatedata.a;
-			remoteRef = 34ECC923204DF1E30053BBC0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		34ECC926204DF1E30053BBC0 /* libprivatedata-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libprivatedata-tvOS.a";
-			remoteRef = 34ECC925204DF1E30053BBC0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		34F74E351E0733E3001D9901 /* libRCTAnimation.a */ = {
@@ -955,6 +993,34 @@
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		FA82288D22DBAAEF00272B8A /* libjsi.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjsi.a;
+			remoteRef = FA82288C22DBAAEF00272B8A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA82288F22DBAAEF00272B8A /* libjsiexecutor.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjsiexecutor.a;
+			remoteRef = FA82288E22DBAAEF00272B8A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA82289122DBAAEF00272B8A /* libjsi-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libjsi-tvOS.a";
+			remoteRef = FA82289022DBAAEF00272B8A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA82289322DBAAEF00272B8A /* libjsiexecutor-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libjsiexecutor-tvOS.a";
+			remoteRef = FA82289222DBAAEF00272B8A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -964,6 +1030,13 @@
 			files = (
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA82285C22DBAAEF00272B8A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -984,13 +1057,35 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
-		39B130511F44D996A17764D3 /* [CP] Copy Pods Resources */ = {
+		3EB547D68CAFD3BC6C4BB928 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-exampleTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4F7C919802AEC80F309618A2 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-example/Pods-example-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-example/Pods-example-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/QBImagePickerController/QBImagePicker.bundle",
 				"${PODS_ROOT}/RSKImageCropper/RSKImageCropper/RSKImageCropperStrings.bundle",
 			);
@@ -1001,19 +1096,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-example/Pods-example-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example/Pods-example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DAF711D8831E8B798A174A11 /* [CP] Check Pods Manifest.lock */ = {
+		6A139BE2D1181D408FA49B08 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			inputFileListPaths = (
 			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
 				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-example-checkManifestLockResult.txt",
 			);
@@ -1034,7 +1133,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA82285A22DBAAEF00272B8A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA82289522DBAB2A00272B8A /* scaleTests.m in Sources */,
+				FA82286122DBAAEF00272B8A /* exampleTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FA82286422DBAAEF00272B8A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 13B07F861A680F5B00A75B9A /* example */;
+			targetProxy = FA82286322DBAAEF00272B8A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
@@ -1051,7 +1167,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B98ADA044EF4A42F2813B5F /* Pods-example.debug.xcconfig */;
+			baseConfigurationReference = 66E59CFF4AE9E25448ABF530 /* Pods-example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1083,7 +1199,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 038E3B40AAC8B9602A0C72CB /* Pods-example.release.xcconfig */;
+			baseConfigurationReference = B6754748A1929D5F492A5FEC /* Pods-example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1198,6 +1314,84 @@
 			};
 			name = Release;
 		};
+		FA82286522DBAAEF00272B8A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 758B4E6C3D257B386B89C375 /* Pods-exampleTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = exampleTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.reactnative.ivpusic.exampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/example.app/example";
+			};
+			name = Debug;
+		};
+		FA82286622DBAAEF00272B8A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 46239C94515094F8E8A62E27 /* Pods-exampleTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = exampleTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.reactnative.ivpusic.exampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/example.app/example";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1215,6 +1409,15 @@
 			buildConfigurations = (
 				83CBBA201A601CBA00E9B192 /* Debug */,
 				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FA82289422DBAAEF00272B8A /* Build configuration list for PBXNativeTarget "exampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FA82286522DBAAEF00272B8A /* Debug */,
+				FA82286622DBAAEF00272B8A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -23,10 +23,10 @@
 		34A9DDBD1D7F43320012B1F5 /* QBImagePicker.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 34A9DDB81D7F43220012B1F5 /* QBImagePicker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		34A9DDBF1D7F43320012B1F5 /* RSKImageCropper.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 34A9DDB91D7F43220012B1F5 /* RSKImageCropper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		34F74E571E073501001D9901 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F74E351E0733E3001D9901 /* libRCTAnimation.a */; };
+		39F2D3F92212C7EDD7E000BC /* libPods-exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B275A7D2A3D4CD89C338E9DE /* libPods-exampleTests.a */; };
+		6C43BDCEF8BA21F015C916DE /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 42D6BA993EAAF42643211BB6 /* libPods-example.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
-		9274FB876177FF9BEE41BE44 /* libPods-exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D920125AC04FC375D26DA18 /* libPods-exampleTests.a */; };
 		C7358F2638924AE4ACDF2B3C /* libRCTVideo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B590311A8214ACA88447B83 /* libRCTVideo.a */; };
-		E4EAED5FCBDB5BF7475B4AB0 /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 237B0E5B1D50D157C4C3B021 /* libPods-example.a */; };
 		FA82286122DBAAEF00272B8A /* exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA82286022DBAAEF00272B8A /* exampleTests.m */; };
 		FA82289522DBAB2A00272B8A /* scaleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA82282322DBA69400272B8A /* scaleTests.m */; };
 /* End PBXBuildFile section */
@@ -334,23 +334,24 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = example/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = example/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
-		237B0E5B1D50D157C4C3B021 /* libPods-example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		18E582431066ACD033039606 /* Pods-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.release.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.release.xcconfig"; sourceTree = "<group>"; };
 		34A9DDB81D7F43220012B1F5 /* QBImagePicker.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = QBImagePicker.framework; sourceTree = "<group>"; };
 		34A9DDB91D7F43220012B1F5 /* RSKImageCropper.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RSKImageCropper.framework; sourceTree = "<group>"; };
 		34F74E2D1E0733E2001D9901 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
-		46239C94515094F8E8A62E27 /* Pods-exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-exampleTests.release.xcconfig"; path = "Target Support Files/Pods-exampleTests/Pods-exampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		42D6BA993EAAF42643211BB6 /* libPods-example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B590311A8214ACA88447B83 /* libRCTVideo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTVideo.a; sourceTree = "<group>"; };
-		66E59CFF4AE9E25448ABF530 /* Pods-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.debug.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.debug.xcconfig"; sourceTree = "<group>"; };
-		6D920125AC04FC375D26DA18 /* libPods-exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		758B4E6C3D257B386B89C375 /* Pods-exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-exampleTests.debug.xcconfig"; path = "Target Support Files/Pods-exampleTests/Pods-exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6C1D28EEC8A61DB023083BFB /* Pods-exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-exampleTests.release.xcconfig"; path = "Target Support Files/Pods-exampleTests/Pods-exampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
-		B6754748A1929D5F492A5FEC /* Pods-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.release.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.release.xcconfig"; sourceTree = "<group>"; };
+		B12E490BDC649D3FBB998654 /* Pods-exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-exampleTests.debug.xcconfig"; path = "Target Support Files/Pods-exampleTests/Pods-exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		B275A7D2A3D4CD89C338E9DE /* libPods-exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAE92B1397B64654977AE8E7 /* RCTVideo.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTVideo.xcodeproj; path = "../node_modules/react-native-video/ios/RCTVideo.xcodeproj"; sourceTree = "<group>"; };
+		F384BEAFC423785C9AFCE37A /* Pods-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.debug.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.debug.xcconfig"; sourceTree = "<group>"; };
 		FA82282322DBA69400272B8A /* scaleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = scaleTests.m; sourceTree = "<group>"; };
 		FA82285E22DBAAEF00272B8A /* exampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = exampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA82286022DBAAEF00272B8A /* exampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = exampleTests.m; sourceTree = "<group>"; };
 		FA82286222DBAAEF00272B8A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FAF8BAD422DBE454000B8591 /* libRNImageCropPicker.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libRNImageCropPicker.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -370,7 +371,7 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				C7358F2638924AE4ACDF2B3C /* libRCTVideo.a in Frameworks */,
-				E4EAED5FCBDB5BF7475B4AB0 /* libPods-example.a in Frameworks */,
+				6C43BDCEF8BA21F015C916DE /* libPods-example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -378,7 +379,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9274FB876177FF9BEE41BE44 /* libPods-exampleTests.a in Frameworks */,
+				39F2D3F92212C7EDD7E000BC /* libPods-exampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -448,8 +449,9 @@
 		030529DF759E681F5FBE907E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				237B0E5B1D50D157C4C3B021 /* libPods-example.a */,
-				6D920125AC04FC375D26DA18 /* libPods-exampleTests.a */,
+				FAF8BAD422DBE454000B8591 /* libRNImageCropPicker.a */,
+				42D6BA993EAAF42643211BB6 /* libPods-example.a */,
+				B275A7D2A3D4CD89C338E9DE /* libPods-exampleTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -612,10 +614,10 @@
 		AADD49662CBAE22320F604C8 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				66E59CFF4AE9E25448ABF530 /* Pods-example.debug.xcconfig */,
-				B6754748A1929D5F492A5FEC /* Pods-example.release.xcconfig */,
-				758B4E6C3D257B386B89C375 /* Pods-exampleTests.debug.xcconfig */,
-				46239C94515094F8E8A62E27 /* Pods-exampleTests.release.xcconfig */,
+				F384BEAFC423785C9AFCE37A /* Pods-example.debug.xcconfig */,
+				18E582431066ACD033039606 /* Pods-example.release.xcconfig */,
+				B12E490BDC649D3FBB998654 /* Pods-exampleTests.debug.xcconfig */,
+				6C1D28EEC8A61DB023083BFB /* Pods-exampleTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -636,13 +638,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "example" */;
 			buildPhases = (
-				6A139BE2D1181D408FA49B08 /* [CP] Check Pods Manifest.lock */,
+				265FD6FED8007D70AB5BD4EE /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				340AECD21D799C3D009F3A60 /* Embed Frameworks */,
-				4F7C919802AEC80F309618A2 /* [CP] Copy Pods Resources */,
+				74069F50B662D6B293841A76 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -657,7 +659,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FA82289422DBAAEF00272B8A /* Build configuration list for PBXNativeTarget "exampleTests" */;
 			buildPhases = (
-				3EB547D68CAFD3BC6C4BB928 /* [CP] Check Pods Manifest.lock */,
+				C841164A528F13B6070B9C2B /* [CP] Check Pods Manifest.lock */,
 				FA82285A22DBAAEF00272B8A /* Sources */,
 				FA82285B22DBAAEF00272B8A /* Frameworks */,
 				FA82285C22DBAAEF00272B8A /* Resources */,
@@ -1057,7 +1059,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
-		3EB547D68CAFD3BC6C4BB928 /* [CP] Check Pods Manifest.lock */ = {
+		265FD6FED8007D70AB5BD4EE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1072,14 +1074,14 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-exampleTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4F7C919802AEC80F309618A2 /* [CP] Copy Pods Resources */ = {
+		74069F50B662D6B293841A76 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1099,7 +1101,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example/Pods-example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6A139BE2D1181D408FA49B08 /* [CP] Check Pods Manifest.lock */ = {
+		C841164A528F13B6070B9C2B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1114,7 +1116,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-example-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-exampleTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1167,7 +1169,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 66E59CFF4AE9E25448ABF530 /* Pods-example.debug.xcconfig */;
+			baseConfigurationReference = F384BEAFC423785C9AFCE37A /* Pods-example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1199,7 +1201,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B6754748A1929D5F492A5FEC /* Pods-example.release.xcconfig */;
+			baseConfigurationReference = 18E582431066ACD033039606 /* Pods-example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1316,7 +1318,7 @@
 		};
 		FA82286522DBAAEF00272B8A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 758B4E6C3D257B386B89C375 /* Pods-exampleTests.debug.xcconfig */;
+			baseConfigurationReference = B12E490BDC649D3FBB998654 /* Pods-exampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1355,7 +1357,7 @@
 		};
 		FA82286622DBAAEF00272B8A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 46239C94515094F8E8A62E27 /* Pods-exampleTests.release.xcconfig */;
+			baseConfigurationReference = 6C1D28EEC8A61DB023083BFB /* Pods-exampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;

--- a/example/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
+++ b/example/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
@@ -42,7 +42,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
+               BlueprintIdentifier = "FA82285D22DBAAEF00272B8A"
                BuildableName = "exampleTests.xctest"
                BlueprintName = "exampleTests"
                ReferencedContainer = "container:example.xcodeproj">
@@ -54,14 +54,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
+               BlueprintIdentifier = "FA82285D22DBAAEF00272B8A"
                BuildableName = "exampleTests.xctest"
                BlueprintName = "exampleTests"
                ReferencedContainer = "container:example.xcodeproj">
@@ -84,7 +83,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/example/ios/exampleTests/Info.plist
+++ b/example/ios/exampleTests/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -16,8 +16,6 @@
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/example/ios/exampleTests/scaleTests.m
+++ b/example/ios/exampleTests/scaleTests.m
@@ -1,0 +1,31 @@
+//
+//  scaleTests.m
+//  example
+//
+//  Created by AP on 14/07/2019.
+//  Copyright © 2019 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "Scale.h"
+
+@interface scaleTests : XCTestCase
+
+@end
+
+@implementation scaleTests
+
+- (void)testScaleByMaxDimensions {
+  CGSize scaled = [Scale scaleWidth:(CGFloat)4032 andHeight:3024 maxWidth:2560 maxHeight:2560];
+  XCTAssertEqual(scaled.width, (double)2560);
+  XCTAssertEqual(scaled.height, (double)1920);
+}
+
+- (void)testScaleByMaxPixels {
+  CGSize scaled = [Scale scaleWidth:(CGFloat)4032 andHeight:3024 maxPixels:5000000];
+  XCTAssertEqual((int)scaled.width, (int)2581);
+  XCTAssertEqual((int)scaled.height, (int)1936);
+}
+
+@end

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ declare module "react-native-image-crop-picker" {
         compressVideoPreset?: string;
         compressImageMaxWidth?: number;
         compressImageMaxHeight?: number;
+        compressImageMaxPixels?: number;
         compressImageQuality?: number;
         loadingLabelText?: string;
         mediaType?: string;

--- a/ios/imageCropPicker.xcodeproj/project.pbxproj
+++ b/ios/imageCropPicker.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		34963AB11D6B96A800F9CA2F /* UIImage+Resize.m in Sources */ = {isa = PBXBuildFile; fileRef = 34963A941D6B919800F9CA2F /* UIImage+Resize.m */; };
 		34EC4AB51D78FEC6001E9E86 /* QBImagePicker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34434E2E1D6F5EA300BF5063 /* QBImagePicker.framework */; };
 		34EC4AB61D78FEC6001E9E86 /* RSKImageCropper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34434E3A1D6F5EBB00BF5063 /* RSKImageCropper.framework */; };
+		FA82289822DBAB7900272B8A /* Scale.m in Sources */ = {isa = PBXBuildFile; fileRef = FA82289722DBAB7900272B8A /* Scale.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,8 @@
 		347ACA051E4B2B2F0068D500 /* libRCTImage.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libRCTImage.a; path = "../../../../Library/Developer/Xcode/DerivedData/example-grvsvunjwoajzcfynrlckgmefufr/Build/Products/Debug-iphonesimulator/libRCTImage.a"; sourceTree = "<group>"; };
 		34963A931D6B919800F9CA2F /* UIImage+Resize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Resize.h"; sourceTree = "<group>"; };
 		34963A941D6B919800F9CA2F /* UIImage+Resize.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Resize.m"; sourceTree = "<group>"; };
+		FA82289622DBAB7900272B8A /* Scale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scale.h; sourceTree = "<group>"; };
+		FA82289722DBAB7900272B8A /* Scale.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Scale.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +121,8 @@
 		34ECC8E3204DEEA90053BBC0 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				FA82289622DBAB7900272B8A /* Scale.h */,
+				FA82289722DBAB7900272B8A /* Scale.m */,
 				3408F5EF1E0DE76F00E97159 /* Compression.h */,
 				3408F5F01E0DE76F00E97159 /* Compression.m */,
 				3400A8141CEB54F3008A0BC7 /* ImageCropPicker.h */,
@@ -167,6 +172,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				de,
 				es,
@@ -219,6 +225,7 @@
 			files = (
 				3408F5F11E0DE76F00E97159 /* Compression.m in Sources */,
 				34963AB11D6B96A800F9CA2F /* UIImage+Resize.m in Sources */,
+				FA82289822DBAB7900272B8A /* Scale.m in Sources */,
 				3400A8161CEB54F3008A0BC7 /* ImageCropPicker.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -37,8 +37,8 @@
 - (ImageResult*) compressImage:(UIImage*)image
                   toDimensions:(CGSize)dimensions
                     intoResult:(ImageResult*)result {
-    
-    NSLog( @"image-crop-picker: compressing image to new width/height: %f/%f", dimensions.width, dimensions.height);
+
+    NSLog(@"image-crop-picker: scaling image width x height: %i x %i -> %i x %i", (int)image.size.width, (int)image.size.height, (int)dimensions.width, (int)dimensions.height);
     
     UIGraphicsBeginImageContext(dimensions);
     [image drawInRect:CGRectMake(0, 0, dimensions.width, dimensions.height)];
@@ -70,14 +70,14 @@
     if (!compressImageMaxPixels) compressImageMaxPixels = 0;
     
     if (compressImageMaxPixels > 0) {
-        NSLog( @"image-crop-picker: compressing image to max pixels: %@", compressImageMaxPixels );
+        NSLog(@"image-crop-picker: scaling image to max pixels: %@", compressImageMaxPixels);
         BOOL shouldResizeImage = [self getPixelCountForImage:image] > [compressImageMaxPixels intValue];
         if (shouldResizeImage) {
             CGSize dimensions = [Scale scaleWidth:image.size.width andHeight:image.size.height maxPixels:[compressImageMaxPixels floatValue]];
             [self compressImage:image toDimensions:dimensions intoResult:result];
         }
     } else {
-        NSLog( @"image-crop-picker: compressing image to max width/height: %@/%@", compressImageMaxWidth, compressImageMaxHeight );
+        NSLog(@"image-crop-picker: scaling image to max width/height: %@/%@", compressImageMaxWidth, compressImageMaxHeight);
         // determine if it is necessary to resize image
         BOOL shouldResizeWidth = (compressImageMaxWidth != nil && [compressImageMaxWidth floatValue] < image.size.width);
         BOOL shouldResizeHeight = (compressImageMaxHeight != nil && [compressImageMaxHeight floatValue] < image.size.height);
@@ -97,7 +97,7 @@
         compressQuality = [NSNumber numberWithFloat:0.8];
     }
     
-    NSLog( @"image-crop-picker: compressing image with image quality: %@", compressQuality);
+    NSLog(@"image-crop-picker: compressing image with image quality: %@", compressQuality);
 
     // convert image to jpeg representation
     result.data = UIImageJPEGRepresentation(result.image, [compressQuality floatValue]);

--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -7,6 +7,7 @@
 //
 
 #import "Compression.h"
+#import "Scale.h"
 
 @implementation Compression
 
@@ -33,35 +34,25 @@
     return self;
 }
 
-- (ImageResult*) compressImageDimensions:(UIImage*)image
-                   compressImageMaxWidth:(CGFloat)maxWidth
-                  compressImageMaxHeight:(CGFloat)maxHeight
-                              intoResult:(ImageResult*)result {
+- (ImageResult*) compressImage:(UIImage*)image
+                  toDimensions:(CGSize)dimensions
+                    intoResult:(ImageResult*)result {
     
-    CGFloat oldWidth = image.size.width;
-    CGFloat oldHeight = image.size.height;
+    NSLog( @"image-crop-picker: compressing image to new width/height: %f/%f", dimensions.width, dimensions.height);
     
-    int newWidth = 0;
-    int newHeight = 0;
-    
-    if (maxWidth < maxHeight) {
-        newWidth = maxWidth;
-        newHeight = (oldHeight / oldWidth) * newWidth;
-    } else {
-        newHeight = maxHeight;
-        newWidth = (oldWidth / oldHeight) * newHeight;
-    }
-    CGSize newSize = CGSizeMake(newWidth, newHeight);
-    
-    UIGraphicsBeginImageContext(newSize);
-    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
+    UIGraphicsBeginImageContext(dimensions);
+    [image drawInRect:CGRectMake(0, 0, dimensions.width, dimensions.height)];
     UIImage *resizedImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     
-    result.width = [NSNumber numberWithFloat:newWidth];
-    result.height = [NSNumber numberWithFloat:newHeight];
+    result.width = [NSNumber numberWithFloat:dimensions.width];
+    result.height = [NSNumber numberWithFloat:dimensions.height];
     result.image = resizedImage;
     return result;
+}
+
+- (NSInteger) getPixelCountForImage:(UIImage*)image {
+    return image.size.width * image.size.height;
 }
 
 - (ImageResult*) compressImage:(UIImage*)image
@@ -75,19 +66,29 @@
     
     NSNumber *compressImageMaxWidth = [options valueForKey:@"compressImageMaxWidth"];
     NSNumber *compressImageMaxHeight = [options valueForKey:@"compressImageMaxHeight"];
+    NSNumber *compressImageMaxPixels = [options valueForKey:@"compressImageMaxPixels"];
+    if (!compressImageMaxPixels) compressImageMaxPixels = 0;
     
-    // determine if it is necessary to resize image
-    BOOL shouldResizeWidth = (compressImageMaxWidth != nil && [compressImageMaxWidth floatValue] < image.size.width);
-    BOOL shouldResizeHeight = (compressImageMaxHeight != nil && [compressImageMaxHeight floatValue] < image.size.height);
-    
-    if (shouldResizeWidth || shouldResizeHeight) {
-        CGFloat maxWidth = compressImageMaxWidth != nil ? [compressImageMaxWidth floatValue] : image.size.width;
-        CGFloat maxHeight = compressImageMaxHeight != nil ? [compressImageMaxHeight floatValue] : image.size.height;
+    if (compressImageMaxPixels > 0) {
+        NSLog( @"image-crop-picker: compressing image to max pixels: %@", compressImageMaxPixels );
+        BOOL shouldResizeImage = [self getPixelCountForImage:image] > [compressImageMaxPixels intValue];
+        if (shouldResizeImage) {
+            CGSize dimensions = [Scale scaleWidth:image.size.width andHeight:image.size.height maxPixels:[compressImageMaxPixels floatValue]];
+            [self compressImage:image toDimensions:dimensions intoResult:result];
+        }
+    } else {
+        NSLog( @"image-crop-picker: compressing image to max width/height: %@/%@", compressImageMaxWidth, compressImageMaxHeight );
+        // determine if it is necessary to resize image
+        BOOL shouldResizeWidth = (compressImageMaxWidth != nil && [compressImageMaxWidth floatValue] < image.size.width);
+        BOOL shouldResizeHeight = (compressImageMaxHeight != nil && [compressImageMaxHeight floatValue] < image.size.height);
         
-        [self compressImageDimensions:image
-                compressImageMaxWidth:maxWidth
-               compressImageMaxHeight:maxHeight
-                           intoResult:result];
+        if (shouldResizeWidth || shouldResizeHeight) {
+            CGFloat maxWidth = compressImageMaxWidth != nil ? [compressImageMaxWidth floatValue] : image.size.width;
+            CGFloat maxHeight = compressImageMaxHeight != nil ? [compressImageMaxHeight floatValue] : image.size.height;
+            
+            CGSize dimensions = [Scale scaleWidth:image.size.width andHeight:image.size.height maxWidth:maxWidth maxHeight:maxHeight];
+            [self compressImage:image toDimensions:dimensions intoResult:result];
+        }
     }
     
     // parse desired image quality
@@ -96,6 +97,8 @@
         compressQuality = [NSNumber numberWithFloat:0.8];
     }
     
+    NSLog( @"image-crop-picker: compressing image with image quality: %@", compressQuality);
+
     // convert image to jpeg representation
     result.data = UIImageJPEGRepresentation(result.image, [compressQuality floatValue]);
     

--- a/ios/src/Scale.h
+++ b/ios/src/Scale.h
@@ -1,0 +1,26 @@
+//
+//  Scale.h
+//  imageCropPicker
+//
+//  Created by AP on 13/07/2019.
+//  Copyright © 2019 Ivan Pusic. All rights reserved.
+//
+
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+//#import <AVFoundation/AVFoundation.h>
+
+@interface Scale : NSObject
+
++ (CGSize) scaleWidth:(CGFloat)width
+            andHeight:(CGFloat)height
+             maxWidth:(CGFloat)maxWidth
+            maxHeight:(CGFloat)maxHeight;
+    
+
++ (CGSize) scaleWidth:(CGFloat)width
+            andHeight:(CGFloat)height
+            maxPixels:(CGFloat)maxPixels;
+
+@end

--- a/ios/src/Scale.m
+++ b/ios/src/Scale.m
@@ -1,0 +1,42 @@
+//
+//  Scale.m
+//  imageCropPicker
+//
+//  Created by AP on 13/07/2019.
+//  Copyright © 2019 Ivan Pusic. All rights reserved.
+//
+
+#import "Scale.h"
+
+@implementation Scale
+
++ (CGSize) scaleWidth:(CGFloat)width
+            andHeight:(CGFloat)height
+             maxWidth:(CGFloat)maxWidth
+            maxHeight:(CGFloat)maxHeight {
+    
+    CGFloat scaleFactor = ((maxWidth / width) < (maxHeight / height)) ? (maxWidth / width) : (maxHeight / height);
+    
+    int newWidth = width * scaleFactor;
+    int newHeight = height * scaleFactor;
+
+    return CGSizeMake(newWidth, newHeight);
+}
+
++ (CGSize) scaleWidth:(CGFloat)width
+            andHeight:(CGFloat)height
+            maxPixels:(CGFloat)maxPixels {
+
+    CGFloat currentPixels = width * height;
+    CGFloat scale = 1.0;
+    if (currentPixels > maxPixels && currentPixels > 0 && maxPixels > 0) {
+        scale = 1.0 / sqrt(currentPixels / maxPixels);
+    }
+    
+    CGFloat newWidth = (int)(width * scale);
+    CGFloat newHeight = (int)(height * scale);
+
+    return CGSizeMake(newWidth, newHeight);
+}
+
+@end

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "homepage": "https://github.com/ivpusic/react-native-image-crop-picker#readme",
   "peerDependencies": {
     "react-native": ">=0.40.0"
+  },
+  "devDependencies": {
+    "react-native": "^0.59.10"
   }
 }


### PR DESCRIPTION
I wanted to be able to scale the image dimensions with a constraint in total pixels as opposed to a maximum width or height, as I was running into fairly wide images, which would end up a bit smaller than desired using the max height/width approach.

If a `compressImageMaxPixels` option is provided and is > 0, it takes precedence over `compressImageMaxWidth/compressImageMaxHeight`, and the latter two are ignored.

...

I had a hard time figuring out how to set things up for development of this library, so I took some liberty to guess at the opinion of how it should be set up.  Please let me know if I should change this.

Because I was adding complexity to the scaling portion of the compression code, I pulled out the scaling specific logic into its own file, and also added unit tests for both iOS and Android.  

In the process, I ran into this bug, so I fixed it too: https://github.com/ivpusic/react-native-image-crop-picker/issues/1044

Additional info:

- I could not figure out how to build the library in XCode.  There was no scheme for imageCropPicker.  I was afraid to break the compilation of the library from other projects, so I added the unit tests inside the example app, by adding a exampleTests target.

- I could not get Android to build using the version of gradle in the project, so I upgraded it to the latest, and configured `build.gradle`.  I also added `react-native` as a `devDependency` so I could refer to it from the `build.gradle` configuration.  Seeing that the XCode build looks for react-native in `../../react-native`, it is not consistent for the android equivalent to use a `devDependency`-based react-native from the `node_modules` installation, but I couldn't figure out how to build it otherwise.

