### PR TITLE
Adds a sortOrder flag to sort by creation date on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ ImagePicker.clean().then(() => {
 | mediaType                               |           string (default any)           | Accepted mediaType for image selection, can be one of: 'photo', 'video', or 'any' |
 | showsSelectedCount (ios only)           |           bool (default true)            | Whether to show the number of selected assets |
 | forceJpg (ios only)           |           bool (default false)            | Whether to convert photos to JPG. This will also convert any Live Photo into its JPG representation |
+| sortOrder (ios only)           |           string (default 'none', supported values: 'asc', 'desc', 'none')            | Applies a sort order on the creation date on how media is displayed within the albums/detail photo views when opening the image picker |
 | showCropGuidelines (android only)       |           bool (default true)            | Whether to show the 3x3 grid on top of the image during cropping |
 | showCropFrame (android only)       |           bool (default true)            | Whether to show crop frame during cropping |
 | hideBottomControls (android only)       |           bool (default false)           | Whether to display bottom controls       |

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare module "react-native-image-crop-picker" {
         mediaType?: string;
         showsSelectedCount?: boolean;
         forceJpg?: boolean;
+        sortOrder?: 'none' | 'asc' | 'desc';
         showCropGuidelines?: boolean;
         hideBottomControls?: boolean;
         enableRotationGesture?: boolean;

--- a/ios/QBImagePicker/QBImagePicker/QBAssetsViewController.m
+++ b/ios/QBImagePicker/QBImagePicker/QBAssetsViewController.m
@@ -242,6 +242,14 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
             default:
                 break;
         }
+        
+        if ([self.imagePickerController.sortOrder isEqualToString:@"asc"]) {
+            options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending: YES]];
+        }
+        
+        if ([self.imagePickerController.sortOrder isEqualToString:@"desc"]) {
+            options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending: NO]];
+        }
 
         self.fetchResult = [PHAsset fetchAssetsInAssetCollection:self.assetCollection options:options];
 

--- a/ios/QBImagePicker/QBImagePicker/QBImagePickerController.h
+++ b/ios/QBImagePicker/QBImagePicker/QBImagePickerController.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSUInteger, QBImagePickerMediaType) {
 @property (nonatomic, assign) BOOL allowsMultipleSelection;
 @property (nonatomic, assign) NSUInteger minimumNumberOfSelection;
 @property (nonatomic, assign) NSUInteger maximumNumberOfSelection;
+@property (nonatomic, strong) NSString* sortOrder;
 
 @property (nonatomic, copy) NSString *prompt;
 @property (nonatomic, assign) BOOL showsNumberOfSelectedAssets;

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -91,6 +91,7 @@ RCT_EXPORT_MODULE();
                                 @"mediaType": @"any",
                                 @"showsSelectedCount": @YES,
                                 @"forceJpg": @NO,
+                                @"sortOrder": @"none",
                                 @"cropperCancelText": @"Cancel",
                                 @"cropperChooseText": @"Choose"
                                 };
@@ -316,6 +317,7 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
             imagePickerController.minimumNumberOfSelection = abs([[self.options objectForKey:@"minFiles"] intValue]);
             imagePickerController.maximumNumberOfSelection = abs([[self.options objectForKey:@"maxFiles"] intValue]);
             imagePickerController.showsNumberOfSelectedAssets = [[self.options objectForKey:@"showsSelectedCount"] boolValue];
+            imagePickerController.sortOrder = [self.options objectForKey:@"sortOrder"];
             
             NSArray *smartAlbums = [self.options objectForKey:@"smartAlbums"];
             if (smartAlbums != nil) {
@@ -607,8 +609,10 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                              [lock lock];
                              @autoreleasepool {
                                  UIImage *imgT = [UIImage imageWithData:imageData];
-                                 
+                               
                                  Boolean forceJpg = [[self.options valueForKey:@"forceJpg"] boolValue];
+                               
+                                 Boolean sortOrder = [[self.options valueForKey:@"sortOrder"] boolValue];
 
                                  NSNumber *compressQuality = [self.options valueForKey:@"compressImageQuality"];
                                  Boolean isLossless = (compressQuality == nil || [compressQuality floatValue] >= 0.8);

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -611,8 +611,6 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                  UIImage *imgT = [UIImage imageWithData:imageData];
                                
                                  Boolean forceJpg = [[self.options valueForKey:@"forceJpg"] boolValue];
-                               
-                                 Boolean sortOrder = [[self.options valueForKey:@"sortOrder"] boolValue];
 
                                  NSNumber *compressQuality = [self.options valueForKey:@"compressImageQuality"];
                                  Boolean isLossless = (compressQuality == nil || [compressQuality floatValue] >= 0.8);


### PR DESCRIPTION
Adds support for ordering the photos by creation date (ascending or descending) on iOS. By default, it'll keep the behavior that's currently on the library, which is that sort order is unspecified.

Related issues:
#953