### PR TITLE
check permission before startCropping. Fix of #957

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -396,8 +396,14 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         setConfiguration(options);
         resultCollector.setup(promise, false);
 
-        Uri uri = Uri.parse(options.getString("path"));
-        startCropping(activity, uri);
+        final Uri uri = Uri.parse(options.getString("path"));
+        permissionsCheck(activity, promise, Collections.singletonList(Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
+            @Override
+            public Void call() {
+                startCropping(activity, uri);
+                return null;
+            }
+        });
     }
 
     private String getBase64StringFromFile(String absoluteFilePath) {
@@ -614,7 +620,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         }
     }
 
-    private void startCropping(Activity activity, Uri uri) {
+    private void startCropping(final Activity activity, final Uri uri) {
         UCrop.Options options = new UCrop.Options();
         options.setCompressionFormat(Bitmap.CompressFormat.JPEG);
         options.setCompressionQuality(100);


### PR DESCRIPTION
The `openCropper` function does not check `WRITE_EXTERNAL_STORAGE` permission like `openPicker` or `openCamera` do, so in this PR I checking it (and ask for grant if needed) before startCropping method called. It's is a fix of [#957](https://github.com/ivpusic/react-native-image-crop-picker/issues/957) issue