### PR TITLE
fixed bug when make foto portrait, it rotate

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -38,7 +38,12 @@ class Compression {
 
         Matrix rotationMatrix = new Matrix();
         int rotationAngleInDegrees = getRotationInDegreesForOrientationTag(originalOrientation);
-        rotationMatrix.postRotate(rotationAngleInDegrees);
+
+        if(width > height & originalOrientation == 0){
+            rotationMatrix.postRotate(-90);
+        }else{
+            rotationMatrix.postRotate(rotationAngleInDegrees);
+        }
 
         float ratioBitmap = (float) width / (float) height;
         float ratioMax = (float) maxWidth / (float) maxHeight;


### PR DESCRIPTION
https://github.com/ivpusic/react-native-image-crop-picker/commit/b3606ea940cc02d2eab4f0a33e6ae4b0f6c13fdc not all devices are covered with this change, I added changes that allow you to not flip the picture from the portrait version of the photo on all devices.