### PR TITLE
Fix deprecated RCTImageLoader.h import

### DIFF
--- a/ios/src/ImageCropPicker.h
+++ b/ios/src/ImageCropPicker.h
@@ -12,10 +12,16 @@
 
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
-#import <React/RCTImageLoader.h>
+#import <React/RCTImageURLLoader.h>
+#import <React/RCTImageShadowView.h>
+#import <React/RCTImageView.h>
+#import <React/RCTImageLoaderProtocol.h>
 #else
 #import "RCTBridgeModule.h"
-#import "RCTImageLoader.h"
+#import "RCTImageURLLoader.h"
+#import "RCTImageShadowView.h"
+#import "RCTImageView.h"
+#import "RCTImageLoaderProtocol.h"
 #endif
 
 #if __has_include("QBImagePicker.h")

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -388,7 +388,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 
     NSString *path = [options objectForKey:@"path"];
 
-    [self.bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
+    [[self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:[RCTConvert NSURLRequest:path] callback:^(NSError *error, UIImage *image) {
         if (error) {
             self.reject(ERROR_CROPPER_IMAGE_NOT_FOUND_KEY, ERROR_CROPPER_IMAGE_NOT_FOUND_MSG, nil);
         } else {


### PR DESCRIPTION
I'm using RN 0.61

The IOS project of react-native-image-crop-picker is importing the deprecated RCTImageLoader.h file. React-RCTImage pod doesn't export this header anymore.

With a simple fix, inspired by [this post](https://github.com/react-native-community/react-native-svg/issues/1141#issuecomment-540940897) the lib is working again.