### PR TITLE
Fix crash after video recording in ios13 & xcode11

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -224,7 +224,7 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
                    [picker dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
                        self.resolve(video);
                    }]];
-                   };
+                   });
                }
          ];
     } else {

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -213,6 +213,7 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
              withFileName:fileName
       withLocalIdentifier:nil
                completion:^(NSDictionary* video) {
+                   dispatch_async(dispatch_get_main_queue(), ^{
                    if (video == nil) {
                        [picker dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
                            self.reject(ERROR_CANNOT_PROCESS_VIDEO_KEY, ERROR_CANNOT_PROCESS_VIDEO_MSG, nil);
@@ -223,6 +224,7 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
                    [picker dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
                        self.resolve(video);
                    }]];
+                   };
                }
          ];
     } else {


### PR DESCRIPTION
UI-related code should run in main thread, as exception says:

`Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'threading violation: expected the main thread'`

Fixes #1139