### PR TITLE
CocoaPods - Properly Interpolate Tag Version

### DIFF
--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -1,15 +1,14 @@
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-version = package['version']
 
 Pod::Spec.new do |s|
   s.name             = "RNImageCropPicker"
-  s.version          = version
+  s.version          = package['version']
   s.summary          = package["description"]
   s.requires_arc = true
   s.license      = 'MIT'
   s.homepage     = 'n/a'
   s.authors      = { "ivpusic" => "" }
-  s.source       = { :git => "https://github.com/ivpusic/react-native-image-crop-picker", :tag => 'v#{version}'}
+  s.source       = { :git => "https://github.com/ivpusic/react-native-image-crop-picker", :tag => "v#{s.version}"}
   s.source_files = 'ios/src/*.{h,m}'
   s.platform     = :ios, "8.0"
   s.dependency 'RSKImageCropper'


### PR DESCRIPTION
I faced an issue today where CocoaPods could not properly install this library because the tag version was incorrect.  This should fix that!

Why?
* Ruby uses `"` quotes when interpolation is required.  Using `'` will mean `v#{version}` 
  is used directly rather than providing the version number.

Changes:
1. User Ruby string interpolation when setting the tag version for the source.