### PR TITLE
add posiibility to record video in lower quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ ImagePicker.clean().then(() => {
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |
 | cropperChooseText (ios only)            |           string (default choose)        | Choose button text |
 | cropperCancelText (ios only)            |           string (default Cancel)        | Cancel button text |
+| recordLowQuality                          |           bool (default false)           | Whether to record video in lower quality. See Android: [EXTRA_VIDEO_QUALITY](https://developer.android.com/reference/android/provider/MediaStore.html#EXTRA_VIDEO_QUALITY), iOS: [UIImagePickerControllerQualityType640x480](https://developer.apple.com/documentation/uikit/uiimagepickercontrollerqualitytype/uiimagepickercontrollerqualitytype640x480?language=objc) Note that for iOS video resolution will be even lower than 640x480 if default MediumQuality compressVideoPreset is set
 
 #### Smart Album Types (ios)
 

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -79,6 +79,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     private boolean enableRotationGesture = false;
     private boolean disableCropperColorSetters = false;
     private boolean useFrontCamera = false;
+    private boolean recordLowQuality = false;
     private ReadableMap options;
 
     //Grey 800
@@ -137,6 +138,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         enableRotationGesture = options.hasKey("enableRotationGesture") && options.getBoolean("enableRotationGesture");
         disableCropperColorSetters = options.hasKey("disableCropperColorSetters") && options.getBoolean("disableCropperColorSetters");
         useFrontCamera = options.hasKey("useFrontCamera") && options.getBoolean("useFrontCamera");
+        recordLowQuality = options.hasKey("recordLowQuality") && options.getBoolean("recordLowQuality");
         this.options = options;
     }
 
@@ -324,6 +326,10 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                 cameraIntent.putExtra("android.intent.extras.CAMERA_FACING", 1);
                 cameraIntent.putExtra("android.intent.extras.LENS_FACING_FRONT", 1);
                 cameraIntent.putExtra("android.intent.extra.USE_FRONT_CAMERA", true);
+            }
+
+            if (this.recordLowQuality) {
+                cameraIntent.putExtra(android.provider.MediaStore.EXTRA_VIDEO_QUALITY, 0);
             }
 
             if (cameraIntent.resolveActivity(activity.getPackageManager()) == null) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ declare module "react-native-image-crop-picker" {
         enableRotationGesture?: boolean;
         cropperCancelText?: string;
         cropperChooseText?: string;
+        recordLowQuality?: boolean;
     }
 
     export interface Image {

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -184,7 +184,13 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
 
                 if ([availableTypes containsObject:(NSString *)kUTTypeMovie]) {
                     picker.mediaTypes = [[NSArray alloc] initWithObjects:(NSString *)kUTTypeMovie, nil];
-                    picker.videoQuality = UIImagePickerControllerQualityTypeHigh;
+                    
+                    if ([self.options objectForKey:@"recordLowQuality"]) {
+                        picker.videoQuality = UIImagePickerControllerQualityType640x480;
+                    } else {
+                        picker.videoQuality = UIImagePickerControllerQualityTypeHigh;
+                    }
+                    
                 }
             }
 


### PR DESCRIPTION
Adds possibility to record video in lower quality. For Android uses: [EXTRA_VIDEO_QUALITY](https://developer.android.com/reference/android/provider/MediaStore.html#EXTRA_VIDEO_QUALITY), For iOS sets to 640x480: [UIImagePickerControllerQualityType640x480](https://developer.apple.com/documentation/uikit/uiimagepickercontrollerqualitytype/uiimagepickercontrollerqualitytype640x480?language=objc)