### PR TITLE
Update react-native cli dependency.

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -223,7 +223,7 @@ PODS:
     - React-cxxreact (= 0.61.2)
     - React-jsi (= 0.61.2)
     - ReactCommon/jscallinvoker (= 0.61.2)
-  - RNImageCropPicker (0.25.3):
+  - RNImageCropPicker (0.26.3):
     - QBImagePickerController
     - React-Core
     - React-RCTImage
@@ -260,7 +260,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/jscallinvoker (from `../node_modules/react-native/ReactCommon`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
+  - RNImageCropPicker (from `../..`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -321,7 +321,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   RNImageCropPicker:
-    :path: "../node_modules/react-native-image-crop-picker"
+    :path: "../.."
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -342,7 +342,7 @@ SPEC CHECKSUMS:
   React-jsi: 32285a21b1b24c36060493ed3057a34677d58d09
   React-jsiexecutor: 8909917ff7d8f21a57e443a866fd8d4560e50c65
   React-jsinspector: 111d7d342b07a904c400592e02a2b958f1098b60
-  react-native-video: 2a13be56b84904ce1be3487e2fe61b73e30b6a00
+  react-native-video: 31f90922291b3a3378ee4fa0d74e606646c05231
   React-RCTActionSheet: 89b037c0fb7d2671607cb645760164e7e0c013f6
   React-RCTAnimation: e3cefa93c38c004c318f7ec04b883eb14b8b8235
   React-RCTBlob: d26ac0e313fbf14e7203473fd593ccaaeee8329e
@@ -353,10 +353,10 @@ SPEC CHECKSUMS:
   React-RCTText: e3ef6191cdb627855ff7fe8fa0c1e14094967fb8
   React-RCTVibration: fb54c732fd20405a76598e431aa2f8c2bf527de9
   ReactCommon: 5848032ed2f274fcb40f6b9ec24067787c42d479
-  RNImageCropPicker: bfb3ea9c8622f290532e2fe63f369e0d5a52f597
+  RNImageCropPicker: 8a993e3b6730f7e0d723b4dc5984907ac332f5d4
   RSKImageCropper: a446db0e8444a036b34f3c43db01b2373baa4b2a
   Yoga: 14927e37bd25376d216b150ab2a561773d57911f
 
 PODFILE CHECKSUM: 61ffb4ec62885bf26d3320925ac20ddbefc82e79
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.8.4

--- a/example/package.json
+++ b/example/package.json
@@ -14,6 +14,6 @@
     "react-native-video": "5.1.0-alpha1"
   },
   "devDependencies": {
-    "react-native-cli": "2.0.1"
+    "@react-native-community/cli": "3.0.4"
   }
 }


### PR DESCRIPTION
CocoaPods install in the example app does not work:

```
$ pod install

Command `config` unrecognized. Make sure that you have run `npm install` and that you are inside a react-native project.

[!] Invalid `Podfile` file: 785: unexpected token at ''.

 #  from /foo/react-native-image-crop-picker/example/ios/Podfile:37
 #  -------------------------------------------
 #  
 >    use_native_modules!
 #  end
 #  -------------------------------------------
```
This is because the example app's `package.json` points to react-native CLI v2, which has since been moved to `@react-native-community/cli` V3.  