### PR TITLE
Add imageOutput in Android to fix png layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ ImagePicker.clean().then(() => {
 | writeTempFile (ios only)                |           bool (default true)            | When set to false, does not write temporary files for the selected images. This is useful to improve performance when you are retrieving file contents with the `includeBase64` option and don't need to read files from disk. |
 | includeBase64                           |           bool (default false)           | When set to true, the image file content will be available as a base64-encoded string in the `data` property. Hint: To use this string as an image source, use it like: ``<Image source={{uri: `data:${image.mime};base64,${image.data}`}} />`` |
 | includeExif                           |           bool (default false)           | Include image exif data in the response |
-| avoidEmptySpaceAroundImage            |           bool (default true)           |  When set to true, the image will always fill the mask space. |
+| avoidEmptySpaceAroundImage (ios only)          |           bool (default true)           |  When set to true, the image will always fill the mask space. |
 | cropperActiveWidgetColor (android only) |       string (default `"#424242"`)       | When cropping image, determines ActiveWidget color. |
 | cropperStatusBarColor (android only)    |        string (default `#424242`)        | When cropping image, determines the color of StatusBar. |
 | cropperToolbarColor (android only)      |        string (default `#424242`)        | When cropping image, determines the color of Toolbar. |
@@ -149,6 +149,7 @@ ImagePicker.clean().then(() => {
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |
 | cropperChooseText (ios only)            |           string (default choose)        | Choose button text |
 | cropperCancelText (ios only)            |           string (default Cancel)        | Cancel button text |
+| imageOutput (android only)              |           string (default jpg)           | Can be jpg, png or webp |
 
 #### Smart Album Types (ios)
 

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -80,6 +80,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     private boolean disableCropperColorSetters = false;
     private boolean useFrontCamera = false;
     private ReadableMap options;
+    private String imageOutput = "jpg";
 
     //Grey 800
     private final String DEFAULT_TINT = "#424242";
@@ -137,6 +138,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         enableRotationGesture = options.hasKey("enableRotationGesture") && options.getBoolean("enableRotationGesture");
         disableCropperColorSetters = options.hasKey("disableCropperColorSetters") && options.getBoolean("disableCropperColorSetters");
         useFrontCamera = options.hasKey("useFrontCamera") && options.getBoolean("useFrontCamera");
+        imageOutput = options.hasKey("imageOutput") ? options.getString("imageOutput") : "jpg";
         this.options = options;
     }
 
@@ -622,7 +624,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     private void startCropping(final Activity activity, final Uri uri) {
         UCrop.Options options = new UCrop.Options();
-        options.setCompressionFormat(Bitmap.CompressFormat.JPEG);
+        options.setCompressionFormat(getCompressFormat(imageOutput));
         options.setCompressionQuality(100);
         options.setCircleDimmedLayer(cropperCircleOverlay);
         options.setFreeStyleCropEnabled(freeStyleCropEnabled);
@@ -645,7 +647,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         }
 
         UCrop uCrop = UCrop
-                .of(uri, Uri.fromFile(new File(this.getTmpDir(activity), UUID.randomUUID().toString() + ".jpg")))
+                .of(uri, Uri.fromFile(new File(this.getTmpDir(activity), UUID.randomUUID().toString() + "." + imageOutput)))
                 .withOptions(options);
 
         if (width > 0 && height > 0) {
@@ -711,7 +713,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
             if (cropping) {
                 UCrop.Options options = new UCrop.Options();
-                options.setCompressionFormat(Bitmap.CompressFormat.JPEG);
+                options.setCompressionFormat(getCompressFormat(imageOutput));
                 startCropping(activity, uri);
             } else {
                 try {
@@ -790,7 +792,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             path.mkdirs();
         }
 
-        File image = File.createTempFile(imageFileName, ".jpg", path);
+        File image = File.createTempFile(imageFileName, "." + imageOutput, path);
 
         // Save a file: path for use with ACTION_VIEW intents
         mCurrentMediaPath = "file:" + image.getAbsolutePath();
@@ -828,5 +830,14 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         map.putInt("height", data.getIntExtra(UCrop.EXTRA_OUTPUT_IMAGE_HEIGHT, DEFAULT_VALUE));
 
         return map;
+    }
+
+    private Bitmap.CompressFormat getCompressFormat(String format){
+        if (format == "jpg"){
+            return Bitmap.CompressFormat.JPEG;
+        } else if (format == "png"){
+            return Bitmap.CompressFormat.PNG;
+        }
+        return Bitmap.CompressFormat.WEBP;
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ declare module "react-native-image-crop-picker" {
         cropperCancelText?: string;
         cropperChooseText?: string;
         writeTempFile?: boolean;
+        imageOutput?: 'jpg' | 'png' | 'webp'
     }
 
     export interface Image {


### PR DESCRIPTION
When you try to crop a png, you lose the transparency layer. This PR fix that problem in Android.

Cropping a png in master:
![bad](https://user-images.githubusercontent.com/15233913/72732210-8a057200-3b95-11ea-8796-f972d21ee1c2.png)

Cropping a png with this PR:
![good](https://user-images.githubusercontent.com/15233913/72732236-92f64380-3b95-11ea-8eec-addd6f85e8e1.png)
