### PR TITLE
Image output format for keep transparent layer in png

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ ImagePicker.clean().then(() => {
 | writeTempFile (ios only)                |           bool (default true)            | When set to false, does not write temporary files for the selected images. This is useful to improve performance when you are retrieving file contents with the `includeBase64` option and don't need to read files from disk. |
 | includeBase64                           |           bool (default false)           | When set to true, the image file content will be available as a base64-encoded string in the `data` property. Hint: To use this string as an image source, use it like: ``<Image source={{uri: `data:${image.mime};base64,${image.data}`}} />`` |
 | includeExif                           |           bool (default false)           | Include image exif data in the response |
-| avoidEmptySpaceAroundImage            |           bool (default true)           |  When set to true, the image will always fill the mask space. |
+| avoidEmptySpaceAroundImage (ios only)          |           bool (default true)           |  When set to true, the image will always fill the mask space. |
 | cropperActiveWidgetColor (android only) |       string (default `"#424242"`)       | When cropping image, determines ActiveWidget color. |
 | cropperStatusBarColor (android only)    |        string (default `#424242`)        | When cropping image, determines the color of StatusBar. |
 | cropperToolbarColor (android only)      |        string (default `#424242`)        | When cropping image, determines the color of Toolbar. |
@@ -149,6 +149,7 @@ ImagePicker.clean().then(() => {
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |
 | cropperChooseText (ios only)            |           string (default choose)        | Choose button text |
 | cropperCancelText (ios only)            |           string (default Cancel)        | Cancel button text |
+| imageOutputFormat              |           string (default jpg)           | Can be jpg or png |
 
 #### Smart Album Types (ios)
 

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 class Compression {
 
-    File resize(String originalImagePath, int maxWidth, int maxHeight, int quality) throws IOException {
+    File resize(String originalImagePath, int maxWidth, int maxHeight, int quality, String outputFormat) throws IOException {
         Bitmap original = BitmapFactory.decodeFile(originalImagePath);
 
         int width = original.getWidth();
@@ -63,10 +63,11 @@ class Compression {
             imageDirectory.mkdirs();
         }
 
-        File resizeImageFile = new File(imageDirectory, UUID.randomUUID() + ".jpg");
+        File resizeImageFile = new File(imageDirectory, UUID.randomUUID() + "." + outputFormat);
 
         OutputStream os = new BufferedOutputStream(new FileOutputStream(resizeImageFile));
-        resized.compress(Bitmap.CompressFormat.JPEG, quality, os);
+        Bitmap.CompressFormat compressFormat = getCompressFormat(outputFormat);
+        resized.compress(compressFormat, quality, os);
 
         os.close();
         original.recycle();
@@ -92,6 +93,7 @@ class Compression {
         Integer maxWidth = options.hasKey("compressImageMaxWidth") ? options.getInt("compressImageMaxWidth") : null;
         Integer maxHeight = options.hasKey("compressImageMaxHeight") ? options.getInt("compressImageMaxHeight") : null;
         Double quality = options.hasKey("compressImageQuality") ? options.getDouble("compressImageQuality") : null;
+        String outputFormat = options.hasKey("imageOutputFormat") ? options.getString("imageOutputFormat") : "jpg";
 
         boolean isLossLess = (quality == null || quality == 1.0);
         boolean useOriginalWidth = (maxWidth == null || maxWidth >= bitmapOptions.outWidth);
@@ -123,12 +125,19 @@ class Compression {
             maxHeight = Math.min(maxHeight, bitmapOptions.outHeight);
         }
 
-        return resize(originalImagePath, maxWidth, maxHeight, targetQuality);
+        return resize(originalImagePath, maxWidth, maxHeight, targetQuality, outputFormat);
     }
 
     synchronized void compressVideo(final Activity activity, final ReadableMap options, final String originalVideo, final String compressedVideo, final Promise promise) {
         // todo: video compression
         // failed attempt 1: ffmpeg => slow and licensing issues
         promise.resolve(originalVideo);
+    }
+
+    Bitmap.CompressFormat getCompressFormat(String format){
+        if (format.equals("png")){
+            return Bitmap.CompressFormat.PNG;
+        }
+        return Bitmap.CompressFormat.JPEG;
     }
 }

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -80,6 +80,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     private boolean disableCropperColorSetters = false;
     private boolean useFrontCamera = false;
     private ReadableMap options;
+    private String imageOutputFormat = "jpg";
 
     //Grey 800
     private final String DEFAULT_TINT = "#424242";
@@ -137,6 +138,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         enableRotationGesture = options.hasKey("enableRotationGesture") && options.getBoolean("enableRotationGesture");
         disableCropperColorSetters = options.hasKey("disableCropperColorSetters") && options.getBoolean("disableCropperColorSetters");
         useFrontCamera = options.hasKey("useFrontCamera") && options.getBoolean("useFrontCamera");
+        imageOutputFormat = options.hasKey("imageOutputFormat") ? options.getString("imageOutputFormat") : "jpg";
         this.options = options;
     }
 
@@ -622,7 +624,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     private void startCropping(final Activity activity, final Uri uri) {
         UCrop.Options options = new UCrop.Options();
-        options.setCompressionFormat(Bitmap.CompressFormat.JPEG);
+        options.setCompressionFormat(compression.getCompressFormat(imageOutputFormat));
         options.setCompressionQuality(100);
         options.setCircleDimmedLayer(cropperCircleOverlay);
         options.setFreeStyleCropEnabled(freeStyleCropEnabled);
@@ -645,7 +647,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         }
 
         UCrop uCrop = UCrop
-                .of(uri, Uri.fromFile(new File(this.getTmpDir(activity), UUID.randomUUID().toString() + ".jpg")))
+                .of(uri, Uri.fromFile(new File(this.getTmpDir(activity), UUID.randomUUID().toString() + "." + imageOutputFormat)))
                 .withOptions(options);
 
         if (width > 0 && height > 0) {
@@ -711,7 +713,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
             if (cropping) {
                 UCrop.Options options = new UCrop.Options();
-                options.setCompressionFormat(Bitmap.CompressFormat.JPEG);
+                options.setCompressionFormat(compression.getCompressFormat(imageOutputFormat));
                 startCropping(activity, uri);
             } else {
                 try {
@@ -736,7 +738,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             if (resultUri != null) {
                 try {
                     if (width > 0 && height > 0) {
-                        resultUri = Uri.fromFile(compression.resize(resultUri.getPath(), width, height, 100));
+                        resultUri = Uri.fromFile(compression.resize(resultUri.getPath(), width, height, 100, imageOutputFormat));
                     }
 
                     WritableMap result = getSelection(activity, resultUri, false);
@@ -790,7 +792,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             path.mkdirs();
         }
 
-        File image = File.createTempFile(imageFileName, ".jpg", path);
+        File image = File.createTempFile(imageFileName, "." + imageOutputFormat, path);
 
         // Save a file: path for use with ACTION_VIEW intents
         mCurrentMediaPath = "file:" + image.getAbsolutePath();

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ declare module "react-native-image-crop-picker" {
         cropperCancelText?: string;
         cropperChooseText?: string;
         writeTempFile?: boolean;
+        imageOutputFormat?: 'jpg' | 'png'
     }
 
     export interface Image {

--- a/ios/src/Compression.h
+++ b/ios/src/Compression.h
@@ -26,11 +26,13 @@
 
 @interface Compression : NSObject
 
-- (ImageResult*) compressImage:(UIImage*)image withOptions:(NSDictionary*)options;
-- (void)compressVideo:(NSURL*)inputURL
-            outputURL:(NSURL*)outputURL
-          withOptions:(NSDictionary*)options
-              handler:(void (^)(AVAssetExportSession*))handler;
+- (NSString *)determineMimeTypeFromOutputFormat:(NSString *)outputFormat;
+- (NSData *)convertImageToOutputFormat:(UIImage *)image outputFormat:(NSString *)outputFormat compressQuality:(NSNumber *)compressQuality;
+- (ImageResult *)compressImage:(UIImage *)image withOptions:(NSDictionary *)options;
+- (void)compressVideo:(NSURL *)inputURL
+            outputURL:(NSURL *)outputURL
+          withOptions:(NSDictionary *)options
+              handler:(void (^)(AVAssetExportSession *))handler;
 
 @property NSDictionary *exportPresets;
 

--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -64,6 +64,20 @@
     return result;
 }
 
+- (NSString *)determineMimeTypeFromOutputFormat:(NSString *)outputFormat {
+    if ([outputFormat isEqual: @"png"]) {
+        return @"image/png";
+    }
+    return @"image/jpeg";
+}
+
+- (NSData *)convertImageToOutputFormat:(UIImage*)image outputFormat:(NSString *)outputFormat compressQuality:(NSNumber *)compressQuality {
+    if ([outputFormat isEqual: @"png"]) {
+        return UIImagePNGRepresentation(image);
+    }
+    return UIImageJPEGRepresentation(image, [compressQuality floatValue]);
+}
+
 - (ImageResult*) compressImage:(UIImage*)image
                    withOptions:(NSDictionary*)options {
     
@@ -71,10 +85,12 @@
     result.width = @(image.size.width);
     result.height = @(image.size.height);
     result.image = image;
-    result.mime = @"image/jpeg";
     
     NSNumber *compressImageMaxWidth = [options valueForKey:@"compressImageMaxWidth"];
     NSNumber *compressImageMaxHeight = [options valueForKey:@"compressImageMaxHeight"];
+    NSString *outputFormat = [options valueForKey:@"imageOutputFormat"];
+
+    result.mime = [self determineMimeTypeFromOutputFormat:outputFormat];
     
     // determine if it is necessary to resize image
     BOOL shouldResizeWidth = (compressImageMaxWidth != nil && [compressImageMaxWidth floatValue] < image.size.width);
@@ -96,8 +112,8 @@
         compressQuality = [NSNumber numberWithFloat:0.8];
     }
     
-    // convert image to jpeg representation
-    result.data = UIImageJPEGRepresentation(result.image, [compressQuality floatValue]);
+    // convert image to output format representation
+    result.data = [self convertImageToOutputFormat:result.image outputFormat:outputFormat compressQuality:compressQuality];
     
     return result;
 }

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -93,7 +93,8 @@ RCT_EXPORT_MODULE();
                                 @"forceJpg": @NO,
                                 @"sortOrder": @"none",
                                 @"cropperCancelText": @"Cancel",
-                                @"cropperChooseText": @"Choose"
+                                @"cropperChooseText": @"Choose",
+                                @"imageOutputFormat": @"jpg"
                                 };
         self.compression = [[Compression alloc] init];
     }
@@ -936,7 +937,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     // create temp file
     NSString *tmpDirFullPath = [self getTmpDirectory];
     NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
-    filePath = [filePath stringByAppendingString:@".jpg"];
+    NSString *imageOutputFormat = [@"." stringByAppendingString:[self.options objectForKey:@"imageOutputFormat"]];
+    filePath = [filePath stringByAppendingString:imageOutputFormat];
 
     // save cropped file
     BOOL status = [data writeToFile:filePath atomically:YES];


### PR DESCRIPTION
When you try to crop a png, you lose the transparency layer. This PR fix that problem.

Cropping a png in master:
![bad](https://user-images.githubusercontent.com/15233913/72732210-8a057200-3b95-11ea-8796-f972d21ee1c2.png)

Cropping a png with this PR:
![good](https://user-images.githubusercontent.com/15233913/72732236-92f64380-3b95-11ea-8eec-addd6f85e8e1.png)
