### PR TITLE
Add support for newer versions of Android with image picking

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -579,7 +579,11 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         BitmapFactory.Options options = validateImage(compressedImagePath);
         long modificationDate = new File(path).lastModified();
 
-        image.putString("path", "file://" + compressedImagePath);
+        final Uri filePath = FileProvider.getUriForFile(activity,
+            activity.getApplicationContext().getPackageName() + ".provider",
+            new File(compressedImagePath));
+
+        image.putString("path", filePath.toString());
         image.putInt("width", options.outWidth);
         image.putInt("height", options.outHeight);
         image.putString("mime", options.outMimeType);

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -579,11 +579,17 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         BitmapFactory.Options options = validateImage(compressedImagePath);
         long modificationDate = new File(path).lastModified();
 
-        final Uri filePath = FileProvider.getUriForFile(activity,
-            activity.getApplicationContext().getPackageName() + ".provider",
-            new File(compressedImagePath));
+        String filePath;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                filePath = "file://" + compressedImagePath;
+        } else {
+            filePath = FileProvider.getUriForFile(activity,
+                activity.getApplicationContext().getPackageName() + ".provider",
+                new File(compressedImagePath)).toString();
+        }
+        
 
-        image.putString("path", filePath.toString());
+        image.putString("path", filePath);
         image.putInt("width", options.outWidth);
         image.putInt("height", options.outHeight);
         image.putString("mime", options.outMimeType);

--- a/android/src/main/res/xml/provider_paths.xml
+++ b/android/src/main/res/xml/provider_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="external_files" path="."/>
+    <cache-path name="cache" path="." />
 </paths>


### PR DESCRIPTION
When selecting an image, the file path came like "file://somepath" but newer versions of android require "content://somepath".

If that is not the case, this image cannot be used to share it outside of the app.
This pull request prevents "Exposed beyond app" error.