### PR TITLE
Reset the cached assets when the asset view controller deallocs

### DIFF
--- a/ios/QBImagePicker/QBImagePicker/QBAssetsViewController.m
+++ b/ios/QBImagePicker/QBImagePicker/QBAssetsViewController.m
@@ -142,6 +142,9 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
 
 - (void)dealloc
 {
+    // Reset cache
+    [self resetCachedAssets];
+
     // Deregister observer
     [[PHPhotoLibrary sharedPhotoLibrary] unregisterChangeObserver:self];
 }


### PR DESCRIPTION
Hi

I had a project where I noticed that using the image picker to grab images from your photo libraries on iOS would eat up more memory each time you did it.

I noticed that for whatever reason, PHCachingImageManager seems to be being retained every time you navigate to QBAssetsViewController. I couldn't figure out what was causing that, however telling the PHCachingImageManager to just stop caching when the QBAssetsViewController gets deallocated at least makes it free up most of the memory it is using.