### PR TITLE
Update Compression.m

### DIFF
--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -41,16 +41,11 @@
     CGFloat oldWidth = image.size.width;
     CGFloat oldHeight = image.size.height;
     
-    int newWidth = 0;
-    int newHeight = 0;
-    
-    if (maxWidth < maxHeight) {
-        newWidth = maxWidth;
-        newHeight = (oldHeight / oldWidth) * newWidth;
-    } else {
-        newHeight = maxHeight;
-        newWidth = (oldWidth / oldHeight) * newHeight;
-    }
+    CGFloat scaleFactor = ((maxWidth / oldWidth) < (maxHeight / oldHeight)) ? (maxWidth / oldWidth) : (maxHeight / oldHeight);
+
+    int newWidth = oldWidth * scaleFactor;
+    int newHeight = oldHeight * scaleFactor;
+                                  
     CGSize newSize = CGSizeMake(newWidth, newHeight);
     
     UIGraphicsBeginImageContext(newSize);


### PR DESCRIPTION
Fixes bug where compressImageMaxWidth and compressImageMaxHeight are not respected.

Credit to https://github.com/ivpusic/react-native-image-crop-picker/issues/1044