### PR TITLE
Duration of the picked video (in milliseconds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ ImagePicker.clean().then(() => {
 | height                    | number | Selected image height                    |
 | mime                      | string | Selected image MIME type (image/jpeg, image/png) |
 | size                      | number | Selected image size in bytes             |
+| duration                  | number | Video duration time in milliseconds      |
 | data                      | base64 | Optional base64 selected file representation |
 | exif                      | object | Extracted exif data from image. Response format is platform specific |
 | cropRect                  | object | Cropped image rectangle (width, height, x, y)    |

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -489,6 +489,13 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
         return bmp;
     }
+    
+    private static Long getVideoDuration(String path) {
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        retriever.setDataSource(path);
+
+        return Long.parseLong(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
+    }
 
     private void getVideo(final Activity activity, final String path, final String mime) throws Exception {
         validateVideo(path);
@@ -505,12 +512,14 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                         try {
                             Bitmap bmp = validateVideo(videoPath);
                             long modificationDate = new File(videoPath).lastModified();
+                            long duration = getVideoDuration(videoPath);
 
                             WritableMap video = new WritableNativeMap();
                             video.putInt("width", bmp.getWidth());
                             video.putInt("height", bmp.getHeight());
                             video.putString("mime", mime);
                             video.putInt("size", (int) new File(videoPath).length());
+                            video.putInt("duration", (int) duration);
                             video.putString("path", "file://" + videoPath);
                             video.putString("modificationDate", String.valueOf(modificationDate));
 

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -434,6 +434,10 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
             [outputURL getResourceValue:&fileSizeValue
                                  forKey:NSURLFileSizeKey
                                   error:nil];
+            
+            AVURLAsset *durationFromUrl = [AVURLAsset assetWithURL:outputURL];
+            CMTime time = [durationFromUrl duration];
+            int seconds = ceil(time.value/time.timescale) * 1000;
 
             completion([self createAttachmentResponse:[outputURL absoluteString]
                                              withExif:nil
@@ -444,6 +448,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                            withHeight:[NSNumber numberWithFloat:track.naturalSize.height]
                                              withMime:@"video/mp4"
                                              withSize:fileSizeValue
+                                             withDuration:[NSNumber numberWithFloat:seconds]
                                              withData:nil
                                              withRect:CGRectNull
                                      withCreationDate:nil
@@ -474,7 +479,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
      }];
 }
 
-- (NSDictionary*) createAttachmentResponse:(NSString*)filePath withExif:(NSDictionary*) exif withSourceURL:(NSString*)sourceURL withLocalIdentifier:(NSString*)localIdentifier withFilename:(NSString*)filename withWidth:(NSNumber*)width withHeight:(NSNumber*)height withMime:(NSString*)mime withSize:(NSNumber*)size withData:(NSString*)data withRect:(CGRect)cropRect withCreationDate:(NSDate*)creationDate withModificationDate:(NSDate*)modificationDate {
+- (NSDictionary*) createAttachmentResponse:(NSString*)filePath withExif:(NSDictionary*) exif withSourceURL:(NSString*)sourceURL withLocalIdentifier:(NSString*)localIdentifier withFilename:(NSString*)filename withWidth:(NSNumber*)width withHeight:(NSNumber*)height withMime:(NSString*)mime withSize:(NSNumber*)size withDuration:(NSNumber*)duration withData:(NSString*)data withRect:(CGRect)cropRect withCreationDate:(NSDate*)creationDate withModificationDate:(NSDate*)modificationDate {
     return @{
              @"path": (filePath && ![filePath isEqualToString:(@"")]) ? filePath : [NSNull null],
              @"sourceURL": (sourceURL) ? sourceURL : [NSNull null],
@@ -625,6 +630,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                                                            withHeight:imageResult.height
                                                                              withMime:imageResult.mime
                                                                              withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
+                                                                             withDuration: nil
                                                                              withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0]: nil
                                                                              withRect:CGRectNull
                                                                      withCreationDate:phAsset.creationDate
@@ -750,6 +756,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                              withHeight:imageResult.height
                                                withMime:imageResult.mime
                                                withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
+                                               withDuration: nil
                                                withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : nil
                                                withRect:CGRectNull
                                        withCreationDate:creationDate
@@ -815,6 +822,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                          withHeight:imageResult.height
                                            withMime:imageResult.mime
                                            withSize:[NSNumber numberWithUnsignedInteger:imageResult.data.length]
+                                           withDuration: nil
                                            withData:[[self.options objectForKey:@"includeBase64"] boolValue] ? [imageResult.data base64EncodedStringWithOptions:0] : nil
                                            withRect:cropRect
                                    withCreationDate:self.croppingFile[@"creationDate"]

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -437,7 +437,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
             
             AVURLAsset *durationFromUrl = [AVURLAsset assetWithURL:outputURL];
             CMTime time = [durationFromUrl duration];
-            int seconds = ceil(time.value/time.timescale) * 1000;
+            int milliseconds = ceil(time.value/time.timescale) * 1000;
 
             completion([self createAttachmentResponse:[outputURL absoluteString]
                                              withExif:nil
@@ -448,7 +448,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                            withHeight:[NSNumber numberWithFloat:track.naturalSize.height]
                                              withMime:@"video/mp4"
                                              withSize:fileSizeValue
-                                             withDuration:[NSNumber numberWithFloat:seconds]
+                                             withDuration:[NSNumber numberWithFloat:milliseconds]
                                              withData:nil
                                              withRect:CGRectNull
                                      withCreationDate:nil


### PR DESCRIPTION
PR for possibility to get duration of the picked video.
related issue - https://github.com/ivpusic/react-native-image-crop-picker/issues/181

This PR will be helpful for video validation, especially when you need to set a limit for uploaded video.

**Implemented on both (Android | IOS)**
In **"Response Object"** you will get duration property in milliseconds.

Tested on Android and IOS.

Duration will be available from local file(path) or cloud(any link as well)

Updated READMY file => **Response Object section**

The PR doesn't have additional dependencies or global changes. 