### PR TITLE
Fixes possibly nil window lookup

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -124,7 +124,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (UIViewController*) getRootVC {
-    UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    UIViewController *root = [[[[UIApplication sharedApplication] windows] lastObject] rootViewController];
     while (root.presentedViewController != nil) {
         root = root.presentedViewController;
     }


### PR DESCRIPTION
Good morning! This is a really cool package, but I faced a slight setback when trying to integrate it into [our application](https://github.com/artsy/eigen). The problem lies with some swizzling we do with our application delegate (using [JSDecoupledAppDelegate](https://github.com/JaviSoto/JSDecoupledAppDelegate)). It's not a common practice, especially among React Native applications, but the result is that `[[[UIApplication sharedApplication] delegate] window]` returns `nil`. This causes the call to [`presentViewController:animated:completion:`](https://github.com/ivpusic/react-native-image-crop-picker/blob/a0c7a8f4b591c864c8025d0eb2360b8270311301/ios/src/ImageCropPicker.m#L360) to silently fail. In our app, we typically use `[[UIApplication sharedApplication] keyWindow]` instead, although this was [deprecated in iOS 13](https://developer.apple.com/documentation/uikit/uiapplication/1622924-keywindow). 

This PR changes the library to access the [application's `windows` property](https://developer.apple.com/documentation/uikit/uiapplication/1623104-windows). This is probably a bit more accurate to what you want, since it handles multi-window applications on iPad, and the ordering of the array matches the visual ordering for the user. This means that the last window in the array is always the top-most window that the user most-recently interacted with, which is probably where the modal image picker should be presented.

Happy to clarify anything, and thanks again!