### PR TITLE
[iOS] Fixed to be cropped the same as Android

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -893,10 +893,6 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     [self imageCropViewController:cropViewController didCropImage:image usingCropRect:cropRect];
 }
 
-- (void)cropViewController:(TOCropViewController *)cropViewController didCropToCircularImage:(UIImage *)image withRect:(CGRect)cropRect angle:(NSInteger)angle {
-    [self imageCropViewController:cropViewController didCropImage:image usingCropRect:cropRect];
-}
-
 - (void)cropViewController:(TOCropViewController *)cropViewController didFinishCancelled:(BOOL)cancelled {
     [self dismissCropper:cropViewController selectionDone:NO completion:[self waitAnimationEnd:^{
         if (self.currentSelectionMode == CROPPING) {


### PR DESCRIPTION
Related to : #1290 

If we use `cropperCircleOverlay` in iOS, it's different from Android, it creates a circular cropped image on a white background. 

* **iOS**
![wrong_image](https://user-images.githubusercontent.com/3139234/90771082-bbae0980-e32d-11ea-87a1-aee339605840.jpg)

* **Android**
![correct_image](https://user-images.githubusercontent.com/3139234/90771145-cff20680-e32d-11ea-8c89-f8c6942a283e.jpg)

I think it's good to have the same result regardless of platforms. An image with a white background makes it difficult to use in a service by using `borderRadius`.

Please review positively.
