### PR TITLE
[feature]: Add Cancel API

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ ImagePicker.clean().then(() => {
 });
 ```
 
+### Cancel piker or close camera
+
+If the user cancels the image picker without choosing an image (by pressing the system back button on Android or the Cancel button on iOS) the Promise will be rejected with a cancellation error. You can check for this error using `isCancel(error)` allowing you to ignore it and cleanup any parts of your interface that may not be needed anymore.
+
+```javascript
+import ImagePicker, { isCancel } from "react-native-image-crop-picker";
+
+ImagePicker.openPicker({
+  mediaType: "photo"
+}).then(() => {
+  // ...
+}).catch(error => {
+  if (isCancel(error)) {
+    // User cancelled the picker, exit any dialogs or menus and move on
+  } else {
+    throw error;
+  }
+});
+```
+
 ### Request Object
 
 | Property                                |                   Type                   | Description                           |

--- a/index.d.ts
+++ b/index.d.ts
@@ -470,4 +470,6 @@ declare module "react-native-image-crop-picker" {
     const ImageCropPicker: ImageCropPicker;
 
     export default ImageCropPicker;
+
+    export const isCancel: (error: unknown) => Boolean
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React from 'react';
-
 import {NativeModules} from 'react-native';
 export default NativeModules.ImageCropPicker;
+
+export const isCancel = error =>
+  Boolean(error && error.code === "E_PICKER_CANCELLED");


### PR DESCRIPTION
Now users can use and know about cancel behavior:

```javascript
import ImagePicker, { isCancel } from "react-native-image-crop-picker";
ImagePicker.openPicker({
  mediaType: "photo"
}).then(() => {
  // ...
}).catch(error => {
  if (isCancel(error)) {
    // User cancelled the picker, exit any dialogs or menus and move on
  } else {
    throw error;
  }
});
```