### PR TITLE
Add path field to ImageOptions on typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,7 +141,12 @@ declare module "react-native-image-crop-picker" {
 
     type ImageOptions = CommonOptions & {
         mediaType: 'photo';
-
+        
+        /**
+         * Selected image location. This is null when the `writeTempFile` option is set to `false`.
+         */
+        path: string;
+        
         /**
          * Width of result image when used with `cropping` option.
          */


### PR DESCRIPTION
When I used openCropper method, TypeScript says 'path' is not available field for parameter object type.
The parameter object type of openCropper method is ImageOptions. There is not path field on ImageOptions Type.

![image](https://user-images.githubusercontent.com/25357575/92235118-26df0a80-eeee-11ea-80f0-bf158bb24c21.png)

