### PR TITLE
[android] filter possible image types for cropping

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -342,6 +342,8 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
             if (cropping || mediaType.equals("photo")) {
                 galleryIntent.setType("image/*");
+                String[] mimetypes = {"image/jpeg", "image/png"};
+                galleryIntent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
             } else if (mediaType.equals("video")) {
                 galleryIntent.setType("video/*");
             } else {


### PR DESCRIPTION
Now `react-native-image-crop-picker` allow to choose any `image/*` file for cropping. But related to https://github.com/Yalantis/uCrop/issues/166#issuecomment-245606245 only `libjpeg` and `libpng` under the hood libUCrop. So I think will be useful to filter image files only ready for cropping

ref https://github.com/ivpusic/react-native-image-crop-picker/issues/1367#issuecomment-686576364