### PR TITLE
Update resize function to respect both maxWidth and maxHeight on android and ios

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -41,17 +41,13 @@ class Compression {
         int rotationAngleInDegrees = getRotationInDegreesForOrientationTag(originalOrientation);
         rotationMatrix.postRotate(rotationAngleInDegrees);
 
-        float ratioBitmap = (float) width / (float) height;
-        float ratioMax = (float) maxWidth / (float) maxHeight;
+        float widthRatio = (float) maxWidth / (float) width;
+        float heightRatio = (float) maxHeight / (float) height;
+        // Resize the image by whichever ratio will make the image smaller, satisfying both constraints.
+        float resizeRatio = Math.min(widthRatio, heightRatio);
 
-        int finalWidth = maxWidth;
-        int finalHeight = maxHeight;
-
-        if (ratioMax > 1) {
-            finalWidth = (int) ((float) maxHeight * ratioBitmap);
-        } else {
-            finalHeight = (int) ((float) maxWidth / ratioBitmap);
-        }
+        int finalWidth = width * resizeRatio;
+        int finalHeight = height * resizeRatio;
 
         Bitmap resized = Bitmap.createScaledBitmap(original, finalWidth, finalHeight, true);
         resized = Bitmap.createBitmap(resized, 0, 0, finalWidth, finalHeight, rotationMatrix, true);

--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -41,16 +41,13 @@
     CGFloat oldWidth = image.size.width;
     CGFloat oldHeight = image.size.height;
     
-    int newWidth = 0;
-    int newHeight = 0;
-    
-    if (maxWidth < maxHeight) {
-        newWidth = maxWidth;
-        newHeight = (oldHeight / oldWidth) * newWidth;
-    } else {
-        newHeight = maxHeight;
-        newWidth = (oldWidth / oldHeight) * newHeight;
-    }
+    CGFloat widthRatio = maxWidth / oldWidth;
+    CGFloat heightRatio = maxHeight / oldHeight;
+    // Resize the image by whichever ratio will make the image smaller, satisfying both constraints.
+    CGFloat resizeRatio = widthRatio < heightRatio ? widthRatio : heightRatio;
+
+    int newWidth = oldWidth * resizeRatio;
+    int newHeight = oldHeight * resizeRatio;
     CGSize newSize = CGSizeMake(newWidth, newHeight);
     
     UIGraphicsBeginImageContext(newSize);


### PR DESCRIPTION
This is a problem that several others have pointed out and submitted PRs for, but I think my solution is slightly more elegant than any other I've seen ;) so I'll add it into the mix. Ultimately, though, it of course doesn't matter which one is accepted as long as the issue is resolved.

If `compressImageMaxWidth` and `compressImageMaxHeight` are both specified, they should both be respected. Currently, only the smaller one is respected. This is only a resonable approach for square images. In general, to satisfy both constraints, one can:
- Determine the scaling factors necessary to satisfy each constraint individually
- Apply the resizing that produces the smaller final image.

For example:
- An image is originally `2000 x 3000`
- I specify `maxWidth=500` and `maxHeight=600`
- The width constraint requires a scaling factor of `500 / 2000 = 0.25`
- The height constraint requires a scaling factor of `600 / 3000 = 0.20`
- Apply the smaller scaling factor of `0.20`, which represents the stronger constraint
- The final image is `400 x 600`. Both constraints are satisfied.

Related (there may be others):
#995 #1147 #1287 #1391 #1440 

Thanks!
Oliver