### PR TITLE
Added useCroppedDimensions to iOS to keep the cropped rect size

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -316,6 +316,14 @@ declare module "react-native-image-crop-picker" {
          * @default Android: 1, iOS: 0.8
          */
         compressImageQuality?: number;
+
+        /**
+         * When cropping image, uses the dimensions of the cropRect for the resulting image.
+         *
+         * @platform iOS only
+         * @default false
+         */
+        useCroppedDimensions?: boolean;
     }
 
     type CropperOptions = ImageOptions & {

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -71,7 +71,8 @@ RCT_EXPORT_MODULE();
             @"forceJpg": @NO,
             @"sortOrder": @"none",
             @"cropperCancelText": @"Cancel",
-            @"cropperChooseText": @"Choose"
+            @"cropperChooseText": @"Choose",
+            @"useCroppedDimensions": @NO
         };
         self.compression = [[Compression alloc] init];
     }
@@ -795,11 +796,16 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 - (void)imageCropViewController:(UIViewController *)controller
                    didCropImage:(UIImage *)croppedImage
                   usingCropRect:(CGRect)cropRect {
+    CGSize desiredImageSize;
     
-    // we have correct rect, but not correct dimensions
-    // so resize image
-    CGSize desiredImageSize = CGSizeMake([[[self options] objectForKey:@"width"] intValue],
-                                         [[[self options] objectForKey:@"height"] intValue]);
+    if ([[[self options] objectForKey:@"useCroppedDimensions"] boolValue]) {
+        desiredImageSize = cropRect.size;
+    } else {
+        // we have correct rect, but not correct dimensions
+        // so resize image
+        desiredImageSize = CGSizeMake([[[self options] objectForKey:@"width"] intValue],
+                                             [[[self options] objectForKey:@"height"] intValue]);
+    }
     
     UIImage *resizedImage = [croppedImage resizedImageToFitInSize:desiredImageSize scaleIfSmaller:YES];
     ImageResult *imageResult = [self.compression compressImage:resizedImage withOptions:self.options];


### PR DESCRIPTION
We needed to be able to receive the largest possible image, within the bounds of the existing `compressImageMaxWidth` and `compressImageMaxHeight` settings. We found that if we did not set the `height` and `width` it was defaulting to 200, or we had to specify a larger `height` and `width`.