### PR TITLE
fix: Make sure to return precise + platform-consistent permission error code

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -63,8 +63,12 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     private static final String E_NO_IMAGE_DATA_FOUND = "E_NO_IMAGE_DATA_FOUND";
     private static final String E_CAMERA_IS_NOT_AVAILABLE = "E_CAMERA_IS_NOT_AVAILABLE";
     private static final String E_CANNOT_LAUNCH_CAMERA = "E_CANNOT_LAUNCH_CAMERA";
-    private static final String E_PERMISSIONS_MISSING = "E_PERMISSION_MISSING";
     private static final String E_ERROR_WHILE_CLEANING_FILES = "E_ERROR_WHILE_CLEANING_FILES";
+
+    private static final String E_NO_LIBRARY_PERMISSION_KEY = "E_NO_LIBRARY_PERMISSION";
+    private static final String E_NO_LIBRARY_PERMISSION_MSG = "User did not grant library permission.";
+    private static final String E_NO_CAMERA_PERMISSION_KEY = "E_NO_CAMERA_PERMISSION";
+    private static final String E_NO_CAMERA_PERMISSION_MSG = "User did not grant camera permission.";
 
     private String mediaType = "any";
     private boolean multiple = false;
@@ -237,9 +241,19 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                 public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
                     if (requestCode == 1) {
 
-                        for (int grantResult : grantResults) {
+                        for (int permissionIndex = 0; permissionIndex < permissions.length; permissionIndex++) {
+                            String permission = permissions[permissionIndex];
+                            int grantResult = grantResults[permissionIndex];
+
                             if (grantResult == PackageManager.PERMISSION_DENIED) {
-                                promise.reject(E_PERMISSIONS_MISSING, "Required permission missing");
+                                if (permission == Manifest.permission.CAMERA) {
+                                    promise.reject(E_NO_CAMERA_PERMISSION_KEY, E_NO_CAMERA_PERMISSION_MSG);
+                                } else if (permission == Manifest.permission.WRITE_EXTERNAL_STORAGE) {
+                                    promise.reject(E_NO_LIBRARY_PERMISSION_KEY, E_NO_LIBRARY_PERMISSION_KEY);
+                                } else {
+                                    // should not happen, we fallback on E_NO_LIBRARY_PERMISSION_KEY rejection for minimal consistency
+                                    promise.reject(E_NO_LIBRARY_PERMISSION_KEY, "Required permission missing");
+                                }
                                 return true;
                             }
                         }

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -249,7 +249,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                                 if (permission.equals(Manifest.permission.CAMERA)) {
                                     promise.reject(E_NO_CAMERA_PERMISSION_KEY, E_NO_CAMERA_PERMISSION_MSG);
                                 } else if (permission.equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                                    promise.reject(E_NO_LIBRARY_PERMISSION_KEY, E_NO_LIBRARY_PERMISSION_KEY);
+                                    promise.reject(E_NO_LIBRARY_PERMISSION_KEY, E_NO_LIBRARY_PERMISSION_MSG);
                                 } else {
                                     // should not happen, we fallback on E_NO_LIBRARY_PERMISSION_KEY rejection for minimal consistency
                                     promise.reject(E_NO_LIBRARY_PERMISSION_KEY, "Required permission missing");

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -246,9 +246,9 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                             int grantResult = grantResults[permissionIndex];
 
                             if (grantResult == PackageManager.PERMISSION_DENIED) {
-                                if (permission == Manifest.permission.CAMERA) {
+                                if (permission.equals(Manifest.permission.CAMERA)) {
                                     promise.reject(E_NO_CAMERA_PERMISSION_KEY, E_NO_CAMERA_PERMISSION_MSG);
-                                } else if (permission == Manifest.permission.WRITE_EXTERNAL_STORAGE) {
+                                } else if (permission.equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                                     promise.reject(E_NO_LIBRARY_PERMISSION_KEY, E_NO_LIBRARY_PERMISSION_KEY);
                                 } else {
                                     // should not happen, we fallback on E_NO_LIBRARY_PERMISSION_KEY rejection for minimal consistency

--- a/index.d.ts
+++ b/index.d.ts
@@ -431,12 +431,12 @@ declare module "react-native-image-crop-picker" {
     type PickerErrorCodeCommon =
         | 'E_PICKER_CANCELLED'
         | 'E_NO_IMAGE_DATA_FOUND'
-        | 'E_PERMISSION_MISSING'
+        | 'E_NO_LIBRARY_PERMISSION'
+        | 'E_NO_CAMERA_PERMISSION'
         | 'E_ERROR_WHILE_CLEANING_FILES';
 
     type PickerErrorCodeIOS =
         | 'E_PICKER_CANNOT_RUN_CAMERA_ON_SIMULATOR'
-        | 'E_PICKER_NO_CAMERA_PERMISSION'
         | 'E_CROPPER_IMAGE_NOT_FOUND'
         | 'E_CANNOT_SAVE_IMAGE'
         | 'E_CANNOT_PROCESS_VIDEO';

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -12,11 +12,11 @@
 #define ERROR_PICKER_CANNOT_RUN_CAMERA_ON_SIMULATOR_KEY @"E_PICKER_CANNOT_RUN_CAMERA_ON_SIMULATOR"
 #define ERROR_PICKER_CANNOT_RUN_CAMERA_ON_SIMULATOR_MSG @"Cannot run camera on simulator"
 
-#define ERROR_PICKER_NO_CAMERA_PERMISSION_KEY @"E_PICKER_NO_CAMERA_PERMISSION"
-#define ERROR_PICKER_NO_CAMERA_PERMISSION_MSG @"User did not grant camera permission."
+#define ERROR_NO_CAMERA_PERMISSION_KEY @"E_NO_CAMERA_PERMISSION"
+#define ERROR_NO_CAMERA_PERMISSION_MSG @"User did not grant camera permission."
 
-#define ERROR_PICKER_UNAUTHORIZED_KEY @"E_PERMISSION_MISSING"
-#define ERROR_PICKER_UNAUTHORIZED_MSG @"Cannot access images. Please allow access if you want to be able to select images."
+#define ERROR_NO_LIBRARY_PERMISSION_KEY @"E_NO_LIBRARY_PERMISSION"
+#define ERROR_NO_LIBRARY_PERMISSION_MSG @"User did not grant library permission."
 
 #define ERROR_PICKER_CANCEL_KEY @"E_PICKER_CANCELLED"
 #define ERROR_PICKER_CANCEL_MSG @"User cancelled image selection"
@@ -145,7 +145,7 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
 #else
     [self checkCameraPermissions:^(BOOL granted) {
         if (!granted) {
-            self.reject(ERROR_PICKER_NO_CAMERA_PERMISSION_KEY, ERROR_PICKER_NO_CAMERA_PERMISSION_MSG, nil);
+            self.reject(ERROR_NO_CAMERA_PERMISSION_KEY, ERROR_NO_CAMERA_PERMISSION_MSG, nil);
             return;
         }
         
@@ -285,7 +285,7 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
     
     [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
         if (status != PHAuthorizationStatusAuthorized) {
-            self.reject(ERROR_PICKER_UNAUTHORIZED_KEY, ERROR_PICKER_UNAUTHORIZED_MSG, nil);
+            self.reject(ERROR_NO_LIBRARY_PERMISSION_KEY, ERROR_NO_LIBRARY_PERMISSION_MSG, nil);
             return;
         }
         


### PR DESCRIPTION
Hi!

First of all, thanks for the lib and your work on it 💪 


This PR brings consistency in permission-related error codes between iOS & android 
=> breaking change

Fixes #770 


PS: tested on iOS + android (except ios camera flow, due to simulator limitation)