### PR TITLE
Migrate from depreciated method for fetching PHPhotos

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -473,6 +473,7 @@ declare module "react-native-image-crop-picker" {
     export function openCropper(options: CropperOptions): Promise<Image>;
     export function clean(): Promise<void>;
     export function cleanSingle(path: string): Promise<void>;
+    export function getPhotoData(assetId: string): Promise<Image>;
 
     export interface ImageCropPicker {
         openPicker<O extends Options>(options: O): Promise<PossibleArray<O, MediaType<O>>>;
@@ -480,6 +481,7 @@ declare module "react-native-image-crop-picker" {
         openCropper(options: CropperOptions): Promise<Image>;
         clean(): Promise<void>;
         cleanSingle(path: string): Promise<void>;
+        getPhotoData(assetId: string): Promise<Image>;
     }
 
     const ImageCropPicker: ImageCropPicker;

--- a/ios/src/ImageCropPicker.h
+++ b/ios/src/ImageCropPicker.h
@@ -9,6 +9,7 @@
 #define RN_IMAGE_CROP_PICKER_h
 
 #import <Foundation/Foundation.h>
+#import <PhotosUI/PhotosUI.h>
 
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
@@ -48,6 +49,7 @@ UIImagePickerControllerDelegate,
 UINavigationControllerDelegate,
 RCTBridgeModule,
 QBImagePickerControllerDelegate,
+PHPickerViewControllerDelegate,
 TOCropViewControllerDelegate>
 
 typedef enum selectionMode {

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -295,18 +295,20 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
         
         dispatch_async(dispatch_get_main_queue(), ^{
             
-            if (@available(iOS 14, *)) {
-                // Use new PHPicker
-                PHPhotoLibrary *photoLibrary = [PHPhotoLibrary sharedPhotoLibrary];
-                PHPickerConfiguration *config = [[PHPickerConfiguration alloc] initWithPhotoLibrary:photoLibrary];;
-                config.selectionLimit = 0;
-                config.filter = [PHPickerFilter imagesFilter];
+            if (![[self.options objectForKey:@"legacy"] boolValue]) {
+                if (@available(iOS 14, *)) { // needs to be it's own if statement
+                    // Use new PHPicker
+                    PHPhotoLibrary *photoLibrary = [PHPhotoLibrary sharedPhotoLibrary];
+                    PHPickerConfiguration *config = [[PHPickerConfiguration alloc] initWithPhotoLibrary:photoLibrary];;
+                    config.selectionLimit = 0;
+                    config.filter = [PHPickerFilter imagesFilter];
 
-                PHPickerViewController *phPickerController = [[PHPickerViewController alloc] initWithConfiguration:config];
-                phPickerController.delegate = self;
-                [[self getRootVC] presentViewController:phPickerController animated:YES completion:nil];
-                return;
-            };
+                    PHPickerViewController *phPickerController = [[PHPickerViewController alloc] initWithConfiguration:config];
+                    phPickerController.delegate = self;
+                    [[self getRootVC] presentViewController:phPickerController animated:YES completion:nil];
+                    return;
+                };
+            }
             
             // Use legacy picker
             QBImagePickerController *imagePickerController =

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -280,6 +280,19 @@ RCT_REMAP_METHOD(clean, resolver:(RCTPromiseResolveBlock)resolve
     }
 }
 
+RCT_EXPORT_METHOD(getPhotoData:(NSString *)assetId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    PHAsset *phAsset = [[PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:nil] firstObject];
+    [self getPhotoAsset:phAsset completion:^(NSDictionary *image) {
+        if (!image) {
+            reject(ERROR_CANNOT_PROCESS_IMAGE_KEY, ERROR_CANNOT_PROCESS_IMAGE_MSG, nil);
+        } else {
+            resolve(image);
+        }
+    }];
+}
+
 RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -644,6 +644,14 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 // PHPicker didFinishPicking
 -(void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results API_AVAILABLE(ios(14)){
     
+    if ([results count] == 0) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [picker dismissViewControllerAnimated:YES completion:[self waitAnimationEnd:^{
+                self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
+            }]];
+        });
+    }
+    
     NSLock *lock = [[NSLock alloc] init];
     __block int processed = 0;
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-crop-picker",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "Select single or multiple images, with cropping option",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Migrate to using `requestImageForAsset`. (https://developer.apple.com/documentation/photokit/phimagemanager/1616964-requestimageforasset?language=objc)

This change fixes the following issues on iOS:
- Importing a photo that has been offloaded to iCloud may fail
- Synchronous import could cause a photo to be imported twice (one low res and one high res)
- Major performance improvements to photo import