### PR TITLE
Update Android RealPathUtil To Avoid Saving Photos To Cache

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -547,13 +547,13 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         String path;
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            path = RealPathUtil.getRealPathFromURI(activity, uri);
+            path = RealPathUtil.getRealPath(activity, uri);
         } else {
             if (isCamera) {
                 Uri mediaUri = Uri.parse(mCurrentMediaPath);
                 path = mediaUri.getPath();
             } else {
-                path = RealPathUtil.getRealPathFromURI(activity, uri);
+                path = RealPathUtil.getRealPath(activity, uri);
             }
         }
 

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -1,6 +1,6 @@
 package com.reactnative.ivpusic.imagepicker;
 
-import android.annotation.TargetApi;
+import android.annotation.SuppressLint;
 import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
@@ -10,16 +10,74 @@ import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import androidx.loader.content.CursorLoader;
 
-class RealPathUtil {
-    @TargetApi(Build.VERSION_CODES.KITKAT)
-    static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
 
-        final boolean isKitKat = Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT;
+public class RealPathUtil {
+
+    public static String getRealPath(Context context, Uri fileUri) {
+        String realPath;
+        // SDK < API11
+        if (Build.VERSION.SDK_INT < 11) {
+            realPath = RealPathUtil.getRealPathFromURI_BelowAPI11(context, fileUri);
+        }
+        // SDK >= 11 && SDK < 19
+        else if (Build.VERSION.SDK_INT < 19) {
+            realPath = RealPathUtil.getRealPathFromURI_API11to18(context, fileUri);
+        }
+        // SDK > 19 (Android 4.4) and up
+        else {
+            realPath = RealPathUtil.getRealPathFromURI_API19(context, fileUri);
+        }
+        return realPath;
+    }
+
+
+    @SuppressLint("NewApi")
+    public static String getRealPathFromURI_API11to18(Context context, Uri contentUri) {
+        String[] proj = {MediaStore.Images.Media.DATA};
+        String result = null;
+
+        CursorLoader cursorLoader = new CursorLoader(context, contentUri, proj, null, null, null);
+        Cursor cursor = cursorLoader.loadInBackground();
+
+        if (cursor != null) {
+            int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+            cursor.moveToFirst();
+            result = cursor.getString(column_index);
+            cursor.close();
+        }
+        return result;
+    }
+
+    public static String getRealPathFromURI_BelowAPI11(Context context, Uri contentUri) {
+        String[] proj = {MediaStore.Images.Media.DATA};
+        Cursor cursor = context.getContentResolver().query(contentUri, proj, null, null, null);
+        int column_index = 0;
+        String result = "";
+        if (cursor != null) {
+            column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+            cursor.moveToFirst();
+            result = cursor.getString(column_index);
+            cursor.close();
+            return result;
+        }
+        return result;
+    }
+
+    /**
+     * Get a file path from a Uri. This will get the the path for Storage Access
+     * Framework Documents, as well as the _data field for the MediaStore and
+     * other file-based ContentProviders.
+     *
+     * @param context The context.
+     * @param uri     The Uri to query.
+     * @author paulburke
+     */
+    @SuppressLint("NewApi")
+    public static String getRealPathFromURI_API19(final Context context, final Uri uri) {
+
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
         // DocumentProvider
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
@@ -31,24 +89,13 @@ class RealPathUtil {
 
                 if ("primary".equalsIgnoreCase(type)) {
                     return Environment.getExternalStorageDirectory() + "/" + split[1];
-                } else {
-                    final int splitIndex = docId.indexOf(':', 1);
-                    final String tag = docId.substring(0, splitIndex);
-                    final String path = docId.substring(splitIndex + 1);
-
-                    String nonPrimaryVolume = getPathToNonPrimaryVolume(context, tag);
-                    if (nonPrimaryVolume != null) {
-                        String result = nonPrimaryVolume + "/" + path;
-                        File file = new File(result);
-                        if (file.exists() && file.canRead()) {
-                            return result;
-                        }
-                        return null;
-                    }
                 }
+
+                // TODO handle non-primary volumes
             }
             // DownloadsProvider
             else if (isDownloadsDocument(uri)) {
+
                 final String id = DocumentsContract.getDocumentId(uri);
                 final Uri contentUri = ContentUris.withAppendedId(
                         Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
@@ -71,7 +118,7 @@ class RealPathUtil {
                 }
 
                 final String selection = "_id=?";
-                final String[] selectionArgs = new String[] {
+                final String[] selectionArgs = new String[]{
                         split[1]
                 };
 
@@ -80,9 +127,11 @@ class RealPathUtil {
         }
         // MediaStore (and general)
         else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
             // Return the remote address
             if (isGooglePhotosUri(uri))
                 return uri.getLastPathSegment();
+
             return getDataColumn(context, uri, null, null);
         }
         // File
@@ -94,71 +143,30 @@ class RealPathUtil {
     }
 
     /**
-     * If an image/video has been selected from a cloud storage, this method
-     * should be call to download the file in the cache folder.
-     *
-     * @param context The context
-     * @param fileName donwloaded file's name
-     * @param uri file's URI
-     * @return file that has been written
-     */
-    private static File writeToFile(Context context, String fileName, Uri uri) {
-        String tmpDir = context.getCacheDir() + "/react-native-image-crop-picker";
-        Boolean created = new File(tmpDir).mkdir();
-        fileName = fileName.substring(fileName.lastIndexOf('/') + 1);
-        File path = new File(tmpDir);
-        File file = new File(path, fileName);
-        try {
-            FileOutputStream oos = new FileOutputStream(file);
-            byte[] buf = new byte[8192];
-            InputStream is = context.getContentResolver().openInputStream(uri);
-            int c = 0;
-            while ((c = is.read(buf, 0, buf.length)) > 0) {
-                oos.write(buf, 0, c);
-                oos.flush();
-            }
-            oos.close();
-            is.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return file;
-    }
-
-    /**
      * Get the value of the data column for this Uri. This is useful for
      * MediaStore Uris, and other file-based ContentProviders.
      *
-     * @param context The context.
-     * @param uri The Uri to query.
-     * @param selection (Optional) Filter used in the query.
+     * @param context       The context.
+     * @param uri           The Uri to query.
+     * @param selection     (Optional) Filter used in the query.
      * @param selectionArgs (Optional) Selection arguments used in the query.
      * @return The value of the _data column, which is typically a file path.
      */
-    private static String getDataColumn(Context context, Uri uri, String selection,
-                                        String[] selectionArgs) {
+    public static String getDataColumn(Context context, Uri uri, String selection,
+                                       String[] selectionArgs) {
 
         Cursor cursor = null;
+        final String column = "_data";
         final String[] projection = {
-                MediaStore.MediaColumns.DATA,
-                MediaStore.MediaColumns.DISPLAY_NAME,
+                column
         };
 
         try {
             cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
                     null);
             if (cursor != null && cursor.moveToFirst()) {
-                // Fall back to writing to file if _data column does not exist
-                final int index = cursor.getColumnIndex(MediaStore.MediaColumns.DATA);
-                String path = index > -1 ? cursor.getString(index) : null;
-                if (path != null) {
-                    return cursor.getString(index);
-                } else {
-                    final int indexDisplayName = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME);
-                    String fileName = cursor.getString(indexDisplayName);
-                    File fileWritten = writeToFile(context, fileName, uri);
-                    return fileWritten.getAbsolutePath();
-                }
+                final int index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(index);
             }
         } finally {
             if (cursor != null)
@@ -172,7 +180,7 @@ class RealPathUtil {
      * @param uri The Uri to check.
      * @return Whether the Uri authority is ExternalStorageProvider.
      */
-    private static boolean isExternalStorageDocument(Uri uri) {
+    public static boolean isExternalStorageDocument(Uri uri) {
         return "com.android.externalstorage.documents".equals(uri.getAuthority());
     }
 
@@ -180,7 +188,7 @@ class RealPathUtil {
      * @param uri The Uri to check.
      * @return Whether the Uri authority is DownloadsProvider.
      */
-    private static boolean isDownloadsDocument(Uri uri) {
+    public static boolean isDownloadsDocument(Uri uri) {
         return "com.android.providers.downloads.documents".equals(uri.getAuthority());
     }
 
@@ -188,7 +196,7 @@ class RealPathUtil {
      * @param uri The Uri to check.
      * @return Whether the Uri authority is MediaProvider.
      */
-    private static boolean isMediaDocument(Uri uri) {
+    public static boolean isMediaDocument(Uri uri) {
         return "com.android.providers.media.documents".equals(uri.getAuthority());
     }
 
@@ -196,27 +204,8 @@ class RealPathUtil {
      * @param uri The Uri to check.
      * @return Whether the Uri authority is Google Photos.
      */
-    private static boolean isGooglePhotosUri(Uri uri) {
+    public static boolean isGooglePhotosUri(Uri uri) {
         return "com.google.android.apps.photos.content".equals(uri.getAuthority());
-    }
-
-    @TargetApi(Build.VERSION_CODES.KITKAT)
-    private static String getPathToNonPrimaryVolume(Context context, String tag) {
-        File[] volumes = context.getExternalCacheDirs();
-        if (volumes != null) {
-            for (File volume : volumes) {
-                if (volume != null) {
-                    String path = volume.getAbsolutePath();
-                    if (path != null) {
-                        int index = path.indexOf(tag);
-                        if (index != -1) {
-                            return path.substring(0, index) + tag;
-                        }
-                    }
-                }
-            }
-        }
-        return null;
     }
 
 }


### PR DESCRIPTION
The current implementation of RealPathUtil will fail to resolve a valid path on newer version of Android, creating the need to read the image data and write it to disk in the cache directory. This is problematic for both performance and reliability reasons (we can't count on those cached files being preserved). 

This refactor makes it easy to understand exactly how we are handing path resolution for each OS version, and fixes this flaw in newer versions of Android