### PR TITLE
Pick current video version instead of original one on iOS

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -463,7 +463,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 - (void) getVideoAsset:(PHAsset*)forAsset completion:(void (^)(NSDictionary* image))completion {
     PHImageManager *manager = [PHImageManager defaultManager];
     PHVideoRequestOptions *options = [[PHVideoRequestOptions alloc] init];
-    options.version = PHVideoRequestOptionsVersionOriginal;
+    options.version = PHVideoRequestOptionsVersionCurrent;
     options.networkAccessAllowed = YES;
     options.deliveryMode = PHVideoRequestOptionsDeliveryModeHighQualityFormat;
     


### PR DESCRIPTION
### Before
When editing a video with iOS tools (edit, trim) and picking it with `ImagePicker.openPicker`, the original video is retrieved instead of the edited (current) one.

### After 
Given the same scenario, the edited (current) video is retrieved instead of the original one.