### PR TITLE
feat: added support for custom media picker in android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,4 +23,7 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.github.yalantis:ucrop:2.2.6-native'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
+    implementation 'com.zhihu.android:matisse:0.5.3-beta3'
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,6 @@ declare module "react-native-image-crop-picker" {
         /**
          * Max number of files to select when using `multiple` option.
          *
-         * @platform iOS only
          * @default 5
          */
         maxFiles?: number;
@@ -137,6 +136,13 @@ declare module "react-native-image-crop-picker" {
          * @default true
          */
         writeTempFile?: boolean;
+        
+        /**
+         * Max number of files to select when using `multiple` option.
+         * @platform Android only
+         * @default false
+         */
+         useStockGallery?: boolean;
     }
 
     type ImageOptions = CommonOptions & {


### PR DESCRIPTION
Currently, react-native-image-crop-picker uses the android stock gallery for selecting the images. But as of now, the maximum file limit support is not available with the stock android gallery.

- So, used https://github.com/zhihu/Matisse library to support max files prop.in android
- added **useStockGallery** prop to choose between stock gallery vs the above image picker 