### PR TITLE
fix freeStyleCropEnabled in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ ImagePicker.clean().then(() => {
 | cropperStatusBarColor (android only)    |        string (default `#424242`)        | When cropping image, determines the color of StatusBar. |
 | cropperToolbarColor (android only)      |        string (default `#424242`)        | When cropping image, determines the color of Toolbar. |
 | cropperToolbarWidgetColor (android only)      |        string (default `darker orange`)        | When cropping image, determines the color of Toolbar text and buttons. |
-| freeStyleCropEnabled (android only)      |        bool (default false)        | Enables user to apply custom rectangle area for cropping |
+| freeStyleCropEnabled      |        bool (default false)        | Enables user to apply custom rectangle area for cropping |
 | cropperToolbarTitle                     |        string (default `Edit Photo`)     | When cropping image, determines the title of Toolbar. |
 | cropperCircleOverlay                    |           bool (default false)           | Enable or disable circular cropping mask. |
 | disableCropperColorSetters (android only)|           bool (default false)           | When cropping image, disables the color setters for cropping library. |


### PR DESCRIPTION
This PR removes the text `(android only)` in the documentation for freeStyleCropEnabled because this feature actually works on ios.