### PR TITLE
Remove WRITE_EXTERNAL_STORAGE permission from SDK 19 and above

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,7 +7,10 @@
         </intent>
     </queries>
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="18"
+    />
 
     <application>
 

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -230,7 +230,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         }
         List<String> missingPermissions = new ArrayList<>();
 
-        for (String permission : requiredPermissions) {
+        for (String permission : requiredVerConditionallyPermissions) {
             int status = ActivityCompat.checkSelfPermission(activity, permission);
             if (status != PackageManager.PERMISSION_GRANTED) {
                 missingPermissions.add(permission);

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -42,6 +42,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -223,7 +224,10 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private void permissionsCheck(final Activity activity, final Promise promise, final List<String> requiredPermissions, final Callable<Void> callback) {
-
+        List<String> requiredVerConditionallyPermissions = new LinkedList<>(requiredPermissions);
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            requiredVerConditionallyPermissions.remove(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        }
         List<String> missingPermissions = new ArrayList<>();
 
         for (String permission : requiredPermissions) {


### PR DESCRIPTION
edit "permissionCheck" method to remove the Manifet.WRITE_EXTERNAL_STORAGE check and make compliant with new google guidelines SDK 30