### PR TITLE
fix(export): export named functions to match definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,12 @@
 import React from 'react';
 
 import {NativeModules} from 'react-native';
-export default NativeModules.ImageCropPicker;
+
+const ImageCropPicker = NativeModules.ImageCropPicker;
+
+export default ImageCropPicker;
+export const openPicker = ImageCropPicker.openPicker;
+export const openCamera = ImageCropPicker.openCamera;
+export const openCropper = ImageCropPicker.openCropper;
+export const clean = ImageCropPicker.clean;
+export const cleanSingle = ImageCropPicker.cleanSingle;


### PR DESCRIPTION
We declared that named exports are exist in [`index.d.ts`](https://github.com/ivpusic/react-native-image-crop-picker/blob/master/index.d.ts#L471-L475), but they are not exist in `index.js`.

This PR exports these named exports in `index.js` that we can really use named import and get benefits with tree-shaking like this: 

```ts
import { openCamera } from 'react-native-image-crop-picker

openCamera()
```