### PR TITLE
[iOS] Keep png format if the input mimeType is image/png

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -323,6 +323,8 @@ declare module "react-native-image-crop-picker" {
          * Selected image location
          */
         path: string;
+
+        mimeType?: string;
     }
 
     type VideoOptions = CommonOptions & {

--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -71,33 +71,42 @@
     result.width = @(image.size.width);
     result.height = @(image.size.height);
     result.image = image;
-    result.mime = @"image/jpeg";
-    
-    NSNumber *compressImageMaxWidth = [options valueForKey:@"compressImageMaxWidth"];
-    NSNumber *compressImageMaxHeight = [options valueForKey:@"compressImageMaxHeight"];
-    
-    // determine if it is necessary to resize image
-    BOOL shouldResizeWidth = (compressImageMaxWidth != nil && [compressImageMaxWidth floatValue] < image.size.width);
-    BOOL shouldResizeHeight = (compressImageMaxHeight != nil && [compressImageMaxHeight floatValue] < image.size.height);
-    
-    if (shouldResizeWidth || shouldResizeHeight) {
-        CGFloat maxWidth = compressImageMaxWidth != nil ? [compressImageMaxWidth floatValue] : image.size.width;
-        CGFloat maxHeight = compressImageMaxHeight != nil ? [compressImageMaxHeight floatValue] : image.size.height;
-        
-        [self compressImageDimensions:image
-                compressImageMaxWidth:maxWidth
-               compressImageMaxHeight:maxHeight
-                           intoResult:result];
+
+    NSString *mimeType = options[@"mimeType"];
+
+    if ([mimeType isEqualToString:@"image/png"]) {
+        // Keep png format if mimeType is image/png
+        result.mime = @"image/png";
+        result.data = UIImagePNGRepresentation(result.image);
+    } else {
+        result.mime = @"image/jpeg";
+
+        NSNumber *compressImageMaxWidth = [options valueForKey:@"compressImageMaxWidth"];
+        NSNumber *compressImageMaxHeight = [options valueForKey:@"compressImageMaxHeight"];
+
+        // determine if it is necessary to resize image
+        BOOL shouldResizeWidth = (compressImageMaxWidth != nil && [compressImageMaxWidth floatValue] < image.size.width);
+        BOOL shouldResizeHeight = (compressImageMaxHeight != nil && [compressImageMaxHeight floatValue] < image.size.height);
+
+        if (shouldResizeWidth || shouldResizeHeight) {
+            CGFloat maxWidth = compressImageMaxWidth != nil ? [compressImageMaxWidth floatValue] : image.size.width;
+            CGFloat maxHeight = compressImageMaxHeight != nil ? [compressImageMaxHeight floatValue] : image.size.height;
+
+            [self compressImageDimensions:image
+                    compressImageMaxWidth:maxWidth
+                   compressImageMaxHeight:maxHeight
+                               intoResult:result];
+        }
+
+        // parse desired image quality
+        NSNumber *compressQuality = [options valueForKey:@"compressImageQuality"];
+        if (compressQuality == nil) {
+            compressQuality = [NSNumber numberWithFloat:0.8];
+        }
+
+        // convert image to jpeg representation
+        result.data = UIImageJPEGRepresentation(result.image, [compressQuality floatValue]);
     }
-    
-    // parse desired image quality
-    NSNumber *compressQuality = [options valueForKey:@"compressImageQuality"];
-    if (compressQuality == nil) {
-        compressQuality = [NSNumber numberWithFloat:0.8];
-    }
-    
-    // convert image to jpeg representation
-    result.data = UIImageJPEGRepresentation(result.image, [compressQuality floatValue]);
     
     return result;
 }


### PR DESCRIPTION
This PR is to fix the issue for cropping images with transparent background. Previously the lib always compress image as jpeg so we can't keep the background. This pr returns png image if the specified `mimeType` is `image/png`.