### PR TITLE
Adding support for dark mode in limited permission help

### DIFF
--- a/ios/QBImagePicker/QBImagePicker/QBAlbumsViewController.m
+++ b/ios/QBImagePicker/QBImagePicker/QBAlbumsViewController.m
@@ -29,6 +29,14 @@ static bool isLimitedPermission() {
     return false;
 }
 
+static bool isDarkMode() {
+    if (@available(iOS 13.0, *)) {
+        UITraitCollection *current = UITraitCollection.currentTraitCollection;
+        return current.userInterfaceStyle == UIUserInterfaceStyleDark;
+    }
+    return false;
+}
+
 @interface QBImagePickerController (Private)
 
 @property (nonatomic, strong) NSBundle *assetBundle;
@@ -317,11 +325,16 @@ static bool isLimitedPermission() {
             UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
             cell.tag = indexPath.row;
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
-            [cell setBackgroundColor:[UIColor colorWithRed: 0.97 green: 0.97 blue: 0.97 alpha: 1.00]];
-
             UIButton *manageButton = [UIButton buttonWithType:UIButtonTypeSystem];
-            [manageButton setBackgroundColor:[UIColor colorWithRed: 0.87 green: 0.87 blue: 0.87 alpha: 1.00]];
-            [manageButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+            if (isDarkMode()) {
+                [cell setBackgroundColor:[UIColor colorWithRed: 0.03 green: 0.03 blue: 0.03 alpha: 1.00]];
+                [manageButton setBackgroundColor:[UIColor colorWithRed: 0.13 green: 0.13 blue: 0.13 alpha: 1.00]];
+                [manageButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+            } else {
+                [cell setBackgroundColor:[UIColor colorWithRed: 0.95 green: 0.95 blue: 0.95 alpha: 1.00]];
+                [manageButton setBackgroundColor:[UIColor colorWithRed: 0.85 green: 0.85 blue: 0.85 alpha: 1.00]];
+                [manageButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+            }
             [manageButton addTarget:self action:@selector(managePermissionAction:) forControlEvents:UIControlEventTouchUpInside];
             manageButton.layer.cornerRadius = 12;
             manageButton.contentEdgeInsets = UIEdgeInsetsMake(4, 12, 4, 12);

--- a/ios/QBImagePicker/QBImagePicker/ja.lproj/QBImagePicker.strings
+++ b/ios/QBImagePicker/QBImagePicker/ja.lproj/QBImagePicker.strings
@@ -21,7 +21,7 @@
 "assets.toolbar.items-selected" = "%ld 項目を選択中";
 
 "permission.help" = "選択した限られた数の写真とビデオに許可を与えました。";
-"permission.manage" = "MANAGE";
+"permission.manage" = "管理";
 "permission.title" = "アプリ内のすべての写真にアクセスするには、デバイス設定でライブラリ全体へのアクセスを許可します。";
 "permission.choose_more" = "写真をもっと選択";
 "permission.change_settings" = "設定の変更";

--- a/ios/QBImagePicker/QBImagePicker/zh-Hans.lproj/QBImagePicker.strings
+++ b/ios/QBImagePicker/QBImagePicker/zh-Hans.lproj/QBImagePicker.strings
@@ -21,7 +21,7 @@
 "assets.toolbar.items-selected" = "选择了%ld项";
 
 "permission.help" = "您已授予有限数量的选定照片和视频的权限。";
-"permission.manage" = "MANAGE";
+"permission.manage" = "管理";
 "permission.title" = "要访问您在应用程序中的所有照片，请在设备设置中授予访问您的完整图库的权限。";
 "permission.choose_more" = "选择更多照片";
 "permission.change_settings" = "更改设置";


### PR DESCRIPTION
Fixes https://github.com/ivpusic/react-native-image-crop-picker/issues/1678

And adding missing translations.

![simulator_screenshot_D34A63E9-F120-473E-A48F-8A9B89A86502](https://user-images.githubusercontent.com/1715834/141269944-f5cdadf0-5485-4a8b-b18a-1f5ee96e0e00.png)

