### PR TITLE
Remove "Manifest.permission.CAMERA" permission

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -303,7 +303,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         setConfiguration(options);
         resultCollector.setup(promise, false);
 
-        permissionsCheck(activity, promise, Arrays.asList(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
+        permissionsCheck(activity, promise, Arrays.asList( Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
             @Override
             public Void call() {
                 initiateCamera(activity);


### PR DESCRIPTION
"Manifest.permission.CAMERA" permission is not required when using Intent to invoke an existing camera app.
[https://developer.android.com/guide/topics/media/camera#manifest](https://developer.android.com/guide/topics/media/camera#manifest)