### PR TITLE
Fix android "Invalid image selected" issue

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -3,6 +3,7 @@ package com.reactnative.ivpusic.imagepicker;
 import android.Manifest;
 import android.app.Activity;
 import android.content.ClipData;
+import android.content.Context;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -39,15 +40,19 @@ import com.yalantis.ucrop.UCropActivity;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+
+
 
 class PickerModule extends ReactContextBaseJavaModule implements ActivityEventListener {
 

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -11,6 +11,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.media.MediaMetadataRetriever;
 import android.net.Uri;
+import android.util.Log;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
@@ -488,12 +489,14 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     private void getAsyncSelection(final Activity activity, Uri uri, boolean isCamera) throws Exception {
         String path = resolveRealPath(activity, uri, isCamera);
+        Log.d("image-crop-picker", "getAsyncSelection - path", path);
         if (path == null || path.isEmpty()) {
             resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, "Cannot resolve asset path.");
             return;
         }
 
         String mime = getMimeType(path);
+        Log.d("image-crop-picker", "getAsyncSelection - mime", mime);
         if (mime != null && mime.startsWith("video/")) {
             getVideo(activity, path, mime);
             return;
@@ -579,6 +582,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                 path = mediaUri.getPath();
             } else {
                 path = RealPathUtil.getRealPathFromURI(activity, uri);
+                Log.d("image-crop-picker", "resolveRealPath - real path util - path", path);
             }
         }
 
@@ -586,12 +590,17 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private BitmapFactory.Options validateImage(String path) throws Exception {
+        Log.d("image-crop-picker", "validateImage - path", path);
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
         options.inPreferredConfig = Bitmap.Config.RGB_565;
         options.inDither = true;
 
+        Log.d("image-crop-picker", "validateImage - options", options.toString());
+
         BitmapFactory.decodeFile(path, options);
+
+        Log.d("image-crop-picker", "validateImage - options2", options.toString());
 
         if (options.outMimeType == null || options.outWidth == 0 || options.outHeight == 0) {
             throw new Exception("Invalid image selected");
@@ -601,6 +610,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private WritableMap getImage(final Activity activity, String path) throws Exception {
+        Log.d("image-crop-picker", "getImage - path", path);
         WritableMap image = new WritableNativeMap();
 
         if (path.startsWith("http://") || path.startsWith("https://")) {
@@ -729,8 +739,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                 } else {
                     try {
 
-                        System.out.println("uri");
-                        System.out.println(uri.toString());
+                        Log.d("image-crop-picker", "uri", uri.toString());
                         getAsyncSelection(activity, uri, false);
                     } catch (Exception ex) {
                         resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, ex.getMessage());

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -12,7 +12,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.media.MediaMetadataRetriever;
 import android.net.Uri;
-import android.util.Log;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
@@ -494,14 +493,12 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     private void getAsyncSelection(final Activity activity, Uri uri, boolean isCamera) throws Exception {
         String path = resolveRealPath(activity, uri, isCamera);
-        Log.d("image-crop-picker", "getAsyncSelection - path: "+path);
         if (path == null || path.isEmpty()) {
             resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, "Cannot resolve asset path.");
             return;
         }
 
         String mime = getMimeType(path);
-        Log.d("image-crop-picker", "getAsyncSelection - mime: "+mime);
         if (mime != null && mime.startsWith("video/")) {
             getVideo(activity, path, mime);
             return;
@@ -587,7 +584,6 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                 path = mediaUri.getPath();
             } else {
                 path = RealPathUtil.getRealPathFromURI(activity, uri);
-                Log.d("image-crop-picker", "resolveRealPath - real path util - path: "+path);
             }
         }
 
@@ -660,17 +656,12 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private BitmapFactory.Options validateImage(String path) throws Exception {
-        Log.d("image-crop-picker", "validateImage - path: "+path);
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
         options.inPreferredConfig = Bitmap.Config.RGB_565;
         options.inDither = true;
 
-        Log.d("image-crop-picker", "validateImage - options: "+options.toString());
-
         BitmapFactory.decodeFile(path, options);
-
-        Log.d("image-crop-picker", "validateImage - options2: "+options.toString() );
 
         if (options.outMimeType == null || options.outWidth == 0 || options.outHeight == 0) {
             throw new Exception("Invalid image selected");
@@ -680,7 +671,6 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private WritableMap getImage(final Activity activity, String path) throws Exception {
-        Log.d("image-crop-picker", "getImage - path: "+path);
         WritableMap image = new WritableNativeMap();
 
         if (path.startsWith("http://") || path.startsWith("https://")) {
@@ -808,8 +798,6 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                     startCropping(activity, uri);
                 } else {
                     try {
-
-                        Log.d("image-crop-picker", "uri: "+uri.toString());
                         getAsyncSelection(activity, uri, false);
                     } catch (Exception ex) {
                         resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, ex.getMessage());

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -591,9 +591,20 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && path.startsWith("/storage")) {
-            File copiedFile =  this.createExternalStoragePrivateFile(activity, uri);
-            path = RealPathUtil.getRealPathFromURI(activity, Uri.fromFile(copiedFile));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+
+            String externalCacheDirPath = Uri.fromFile(activity.getExternalCacheDir()).getPath();
+            String externalFilesDirPath = Uri.fromFile(activity.getExternalFilesDir(null)).getPath();
+            String cacheDirPath = Uri.fromFile(activity.getCacheDir()).getPath();
+            String FilesDirPath = Uri.fromFile(activity.getFilesDir()).getPath();
+
+            if (!path.startsWith(externalCacheDirPath)
+                    && !path.startsWith(externalFilesDirPath)
+                    && !path.startsWith(cacheDirPath)
+                    && !path.startsWith(FilesDirPath)) {
+                File copiedFile = this.createExternalStoragePrivateFile(activity, uri);
+                path = RealPathUtil.getRealPathFromURI(activity, Uri.fromFile(copiedFile));
+            }
         }
 
         return path;
@@ -603,7 +614,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         InputStream inputStream = context.getContentResolver().openInputStream(uri);
 
         String extension = this.getExtension(context, uri);
-        File file = new File(context.getExternalFilesDir(null), "/soomgo/temp/" + System.currentTimeMillis() + "." + extension);
+        File file = new File(context.getExternalCacheDir(), "/temp/" + System.currentTimeMillis() + "." + extension);
         File parentFile = file.getParentFile();
         if (parentFile != null) {
             parentFile.mkdirs();

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -16,6 +16,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.util.Base64;
+import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import androidx.core.app.ActivityCompat;

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -489,14 +489,14 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     private void getAsyncSelection(final Activity activity, Uri uri, boolean isCamera) throws Exception {
         String path = resolveRealPath(activity, uri, isCamera);
-        Log.d("image-crop-picker", "getAsyncSelection - path", path);
+        Log.d("image-crop-picker", "getAsyncSelection - path: "+path);
         if (path == null || path.isEmpty()) {
             resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, "Cannot resolve asset path.");
             return;
         }
 
         String mime = getMimeType(path);
-        Log.d("image-crop-picker", "getAsyncSelection - mime", mime);
+        Log.d("image-crop-picker", "getAsyncSelection - mime: "+mime);
         if (mime != null && mime.startsWith("video/")) {
             getVideo(activity, path, mime);
             return;
@@ -582,7 +582,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                 path = mediaUri.getPath();
             } else {
                 path = RealPathUtil.getRealPathFromURI(activity, uri);
-                Log.d("image-crop-picker", "resolveRealPath - real path util - path", path);
+                Log.d("image-crop-picker", "resolveRealPath - real path util - path: "+path);
             }
         }
 
@@ -590,17 +590,17 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private BitmapFactory.Options validateImage(String path) throws Exception {
-        Log.d("image-crop-picker", "validateImage - path", path);
+        Log.d("image-crop-picker", "validateImage - path: "+path);
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
         options.inPreferredConfig = Bitmap.Config.RGB_565;
         options.inDither = true;
 
-        Log.d("image-crop-picker", "validateImage - options", options.toString());
+        Log.d("image-crop-picker", "validateImage - options: "+options.toString());
 
         BitmapFactory.decodeFile(path, options);
 
-        Log.d("image-crop-picker", "validateImage - options2", options.toString());
+        Log.d("image-crop-picker", "validateImage - options2: "+options.toString() );
 
         if (options.outMimeType == null || options.outWidth == 0 || options.outHeight == 0) {
             throw new Exception("Invalid image selected");
@@ -610,7 +610,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     }
 
     private WritableMap getImage(final Activity activity, String path) throws Exception {
-        Log.d("image-crop-picker", "getImage - path", path);
+        Log.d("image-crop-picker", "getImage - path: "+path);
         WritableMap image = new WritableNativeMap();
 
         if (path.startsWith("http://") || path.startsWith("https://")) {
@@ -739,7 +739,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                 } else {
                     try {
 
-                        Log.d("image-crop-picker", "uri", uri.toString());
+                        Log.d("image-crop-picker", "uri: "+uri.toString());
                         getAsyncSelection(activity, uri, false);
                     } catch (Exception ex) {
                         resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, ex.getMessage());

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -728,6 +728,9 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                     startCropping(activity, uri);
                 } else {
                     try {
+
+                        System.out.println("uri");
+                        System.out.println(uri.toString());
                         getAsyncSelection(activity, uri, false);
                     } catch (Exception ex) {
                         resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, ex.getMessage());

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -19,8 +19,8 @@ import java.io.InputStream;
 class RealPathUtil {
     @TargetApi(Build.VERSION_CODES.KITKAT)
     static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
-        Log.d("image-crop-picker", "getRealPathFromURI - uri", uri.toString());
-        Log.d("image-crop-picker", "getRealPathFromURI - scheme", uri.getScheme());
+        Log.d("image-crop-picker", "getRealPathFromURI - uri: "+uri.toString());
+        Log.d("image-crop-picker", "getRealPathFromURI - scheme: "+uri.getScheme());
         final boolean isKitKat = Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT;
 
         // DocumentProvider

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -18,7 +18,8 @@ import java.io.InputStream;
 class RealPathUtil {
     @TargetApi(Build.VERSION_CODES.KITKAT)
     static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
-
+        Log.d("image-crop-picker", "getRealPathFromURI - uri", uri.toString());
+        Log.d("image-crop-picker", "getRealPathFromURI - scheme", uri.getScheme());
         final boolean isKitKat = Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT;
 
         // DocumentProvider
@@ -80,6 +81,7 @@ class RealPathUtil {
         }
         // MediaStore (and general)
         else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
             // Return the remote address
             if (isGooglePhotosUri(uri))
                 return uri.getLastPathSegment();

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -5,7 +5,6 @@ import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
-import android.util.Log;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
@@ -19,8 +18,7 @@ import java.io.InputStream;
 class RealPathUtil {
     @TargetApi(Build.VERSION_CODES.KITKAT)
     static String getRealPathFromURI(final Context context, final Uri uri) throws IOException {
-        Log.d("image-crop-picker", "getRealPathFromURI - uri: "+uri.toString());
-        Log.d("image-crop-picker", "getRealPathFromURI - scheme: "+uri.getScheme());
+
         final boolean isKitKat = Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT;
 
         // DocumentProvider
@@ -82,7 +80,6 @@ class RealPathUtil {
         }
         // MediaStore (and general)
         else if ("content".equalsIgnoreCase(uri.getScheme())) {
-
             // Return the remote address
             if (isGooglePhotosUri(uri))
                 return uri.getLastPathSegment();

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java
@@ -5,6 +5,7 @@ import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.util.Log;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;


### PR DESCRIPTION
"Invalid image selected" error throwing when image path is not readable because of scoped storage.
Copy file to external cache directory when the file is not reachable to resolve this issue.
