### PR TITLE
fix view blinks on ios15 if enable cropping flag

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -893,6 +893,9 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         cropVC.rotateButtonsHidden = [[self.options objectForKey:@"cropperRotateButtonsHidden"] boolValue];
         
         cropVC.modalPresentationStyle = UIModalPresentationFullScreen;
+        if (@available(iOS 15.0, *)) {
+            cropVC.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+        }
         
         [[self getRootVC] presentViewController:cropVC animated:FALSE completion:nil];
     });


### PR DESCRIPTION
fix [#1658 ](https://github.com/ivpusic/react-native-image-crop-picker/issues/1658)