### PR TITLE
feat: Add "any" mediaType support for openCamera

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -168,6 +168,15 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
                 }
             }
             
+            if ([mediaType isEqualToString:@"any"]) {
+                NSArray *availableTypes = [UIImagePickerController availableMediaTypesForSourceType:UIImagePickerControllerSourceTypeCamera];
+
+                if ([availableTypes containsObject:(NSString *)kUTTypeMovie]) {
+                    picker.mediaTypes = [[NSArray alloc] initWithObjects:(NSString *)kUTTypeImage, kUTTypeMovie, nil];
+                    picker.videoQuality = UIImagePickerControllerQualityTypeHigh;
+                }
+            }
+
             if ([[self.options objectForKey:@"useFrontCamera"] boolValue]) {
                 picker.cameraDevice = UIImagePickerControllerCameraDeviceFront;
             }


### PR DESCRIPTION
### Description

This adds support for the `any` mediaType  when using the `openCamera` function on iOS, allowing users to either take a picture or record a video

