### PR TITLE
Get correct root VC when using SceneDelegate on iOS 13+

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -125,7 +125,35 @@ RCT_EXPORT_MODULE();
 }
 
 - (UIViewController*) getRootVC {
-    UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    UIViewController *root = nil;
+    if (@available(iOS 13.0, *)) {
+        for (id scene in [UIApplication sharedApplication].connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]]) {
+                continue;
+            }
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+                if (@available(iOS 15.0, *)) {
+                    root = windowScene.keyWindow.rootViewController;
+                } else {
+                    for (UIWindow *window in windowScene.windows) {
+                        if ([window isKeyWindow]) {
+                            root = [window rootViewController];
+                            break;
+                        }
+                    }
+                }
+                if (root != nil) {
+                    break;
+                }
+            }
+        }
+    }
+
+    if (root == nil) {
+        root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    }
+
     while (root.presentedViewController != nil) {
         root = root.presentedViewController;
     }


### PR DESCRIPTION
Current version of react-native-image-crop-picker can't present picker when app is using SceneDelegate.

On app using SceneDelegate (for multiple window support or CarPlay support), we should get the root VC from the connected window scene.