### PR TITLE
fix(1742):runtime exception in PHPhotoLibrary

### DIFF
--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
     qb.exclude_files    = "ios/QBImagePicker/QBImagePicker/QBImagePicker.h"
     qb.resource_bundles = { "QBImagePicker" => "ios/QBImagePicker/QBImagePicker/*.{lproj,storyboard}" }
     qb.requires_arc     = true
-    qb.frameworks       = "Photos"
+    qb.frameworks       = "Photos", "PhotosUI"
   end
 end


### PR DESCRIPTION
Summary

We have noticed several crashes due to a RuntimeException for our App on iOS devices. The StackTrace given in the Xcode console is as follows.

```
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[PHPhotoLibrary presentLimitedLibraryPickerFromViewController:]: unrecognized selector sent to instance 0x7fd348a7b9b0'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007ff800427378 __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x00007ff80004dbaf objc_exception_throw + 48
	2   CoreFoundation                      0x00007ff800436588 +[NSObject(NSObject) instanceMethodSignatureForSelector:] + 0
	3   CoreFoundation                      0x00007ff80042b83d ___forwarding___ + 1431
	4   CoreFoundation                      0x00007ff80042db38 _CF_forwarding_prep_0 + 120
	5   Dev                                 0x000000010db4101d __49-[QBAlbumsViewController managePermissionAction:]_block_invoke + 125
	6   UIKitCore                           0x0000000121391495 -[UIAlertController _invokeHandlersForAction:] + 105
	7   UIKitCore                           0x0000000121391d7e __103-[UIAlertController _dismissAnimated:triggeringAction:triggeredByPopoverDimmingView:dismissCompletion:]_block_invoke.510 + 16
	8   UIKitCore                           0x0000000121724ed4 -[UIPresentationController transitionDidFinish:] + 1306
	9   UIKitCore                           0x0000000121729bdc __56-[UIPresentationController runTransitionForCurrentState]_block_invoke.447 + 189
	10  UIKitCore                           0x0000000121882842 -[_UIViewControllerTransitionContext completeTransition:] + 101
	11  UIKitCore                           0x000000012275ef41 __UIVIEW_IS_EXECUTING_ANIMATION_COMPLETION_BLOCK__ + 15
	12  UIKitCore                           0x000000012275f260 -[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] + 797
	13  UIKitCore                           0x000000012272ef1e -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 190
	14  UIKitCore                           0x000000012272f539 -[UIViewAnimationState animationDidStop:finished:] + 263
	15  UIKitCore                           0x000000012272f6ba -[UIViewAnimationState animationDidStop:finished:] + 648
	16  QuartzCore                          0x00007ff80890532e _ZN2CA5Layer23run_animation_callbacksEPv + 318
	17  libdispatch.dylib                   0x0000000114244f5b _dispatch_client_callout + 8
	18  libdispatch.dylib                   0x0000000114255d55 _dispatch_main_queue_drain + 1463
	19  libdispatch.dylib                   0x0000000114255790 _dispatch_main_queue_callback_4CF + 31
	20  CoreFoundation                      0x00007ff8003869f7 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
	21  CoreFoundation                      0x00007ff8003813c6 __CFRunLoopRun + 2482
	22  CoreFoundation                      0x00007ff800380637 CFRunLoopRunSpecific + 560
	23  GraphicsServices                    0x00007ff809c0f28a GSEventRunModal + 139
	24  UIKitCore                           0x0000000122143425 -[UIApplication _run] + 994
	25  UIKitCore                           0x0000000122148301 UIApplicationMain + 123
	26  Dev                                 0x000000010d154c08 main + 104
	27  dyld                                0x00000001138282bf start_sim + 10
	28  ???                                 0x000000011917752e 0x0 + 4715935022
)

```

With quick googling i was able to find out this issue on iOS, https://stackoverflow.com/a/71050608/6668308

How To Test 
We are only able to reproduce the bug on iOS.

Steps to reproduce:

1. In iOS Settings give your app **Selected Photos** permission and select no images.
2. Open your app and open image picker
3. Restart the app 
4. Select  **Keep Current Selection** 
5. Press **MANAGE**
6. Select Choose **Select More Photos**

Result prefix: `Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[PHPhotoLibrary presentLimitedLibraryPickerFromViewController:]: unrecognized selector sent to instance 0x7fd348a7b9b0'`

Postfix: no exception occurs.


