### PR TITLE
[iOS only] Feat: Add the way to customize iOS cropper toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ ImagePicker.clean().then(() => {
 | hideBottomControls (android only)       |           bool (default false)           | Whether to display bottom controls       |
 | enableRotationGesture (android only)    |           bool (default false)           | Whether to enable rotating the image by hand gesture |
 | cropperChooseText (ios only)            |           string (default choose)        | Choose button text |
+| cropperChooseColor (ios only)           |           string (default `#FFCC00`)        | HEX format color for the Choose button. [Default color is controlled by TOCropViewController](https://github.com/TimOliver/TOCropViewController/blob/a942414508012b13102f776eb65dac655f31cabb/Objective-C/TOCropViewController/Views/TOCropToolbar.m#L444). |
 | cropperCancelText (ios only)            |           string (default Cancel)        | Cancel button text |
+| cropperCancelColor (ios only)           |           string (default tint `iOS` color )        | HEX format color for the Cancel button. Default value is the default tint iOS color [controlled by TOCropViewController](https://github.com/TimOliver/TOCropViewController/blob/a942414508012b13102f776eb65dac655f31cabb/Objective-C/TOCropViewController/Views/TOCropToolbar.m#L433) |
 | cropperRotateButtonsHidden (ios only)   |           bool (default false)           | Enable or disable cropper rotate buttons |
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -256,11 +256,27 @@ declare module "react-native-image-crop-picker" {
         cropperCancelText?: string;
 
         /**
+         * Cancel button color. HEX-like string color.
+         *
+         * @example '#ff00ee'
+         * @platform iOS only
+         */
+        cropperCancelColor?: string;
+
+        /**
          * Choose button text.
          *
          * @default 'Choose'
          */
         cropperChooseText?: string;
+
+        /**
+         * Choose button color. HEX-like string color.
+         *
+         * @example '#EE00DD'
+         * @platform iOS only
+         */
+        cropperChooseColor?: string;
 
          /**
          * Enable or disable cropper rotate buttons.

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -866,6 +866,15 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     };
 }
 
+// Assumes input like "#00FF00" (#RRGGBB).
++ (UIColor *)colorFromHexString:(NSString *)hexString {
+    unsigned rgbValue = 0;
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    [scanner setScanLocation:1]; // bypass '#' character
+    [scanner scanHexInt:&rgbValue];
+    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+}
+
 #pragma mark - TOCCropViewController Implementation
 - (void)cropImage:(UIImage *)image {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -887,6 +896,16 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         
         cropVC.title = [[self options] objectForKey:@"cropperToolbarTitle"];
         cropVC.delegate = self;
+
+        NSString* rawDoneButtonColor = [self.options objectForKey:@"cropperChooseColor"];
+        NSString* rawCancelButtonColor = [self.options objectForKey:@"cropperCancelColor"];
+
+        if (rawDoneButtonColor) {
+            cropVC.doneButtonColor = [ImageCropPicker colorFromHexString: rawDoneButtonColor];
+        }
+        if (rawCancelButtonColor) {
+            cropVC.cancelButtonColor = [ImageCropPicker colorFromHexString: rawCancelButtonColor];
+        }
         
         cropVC.doneButtonTitle = [self.options objectForKey:@"cropperChooseText"];
         cropVC.cancelButtonTitle = [self.options objectForKey:@"cropperCancelText"];


### PR DESCRIPTION
### What's new
This PR adds a way to customize iOS cropper toolbar using custom (HEX only) colors for the toolbar buttons (`Choose` and `Cancel`).

### Demo
If I would pass custom colors to `openCropper` or `openPicker` it would apply provided colors
`openCropper` example:
```ts
async function launchCropper() {
  const imageUri: string = await SomeImageUtils.openPicker();

  return await ImageCropper.openCropper({
    path: imageUri,
    mediaType: 'photo',
    cropperChooseColor: '#00E78A',
    cropperCancelColor: '#FFFFFF',
  });
}
```
or `openPicker` example:
```ts
async function launchPicker() {
  return await ImageCropper.openPicker({
    cropperChooseColor: '#00E78A',
    cropperCancelColor: '#FFFFFF',
  });
}
```
![Simulator Screenshot - iPhone 14 Pro Max - 2023-05-12 at 10 56 53](https://github.com/ivpusic/react-native-image-crop-picker/assets/62186274/d19c0dab-4678-4529-815f-c350215b8d87)


And if I would not pass any custom colors it would fallback to default values
`openCropper` example:
```ts
async function launchCropper() {
  const imageUri: string = await SomeImageUtils.openPicker();

  return await ImageCropper.openCropper({
    path: imageUri,
    mediaType: 'photo'
  });
}
```
or `openPicker` example:
```ts
async function launchPicker() {
  return await ImageCropper.openPicker();
}
```
![Simulator Screenshot - iPhone 14 Pro Max - 2023-05-12 at 10 55 09](https://github.com/ivpusic/react-native-image-crop-picker/assets/62186274/d3fef2af-854d-4e49-9c67-e0ff8083eaa0)

### How it was tested
It was manually QA in iOS Simulator (iOS 15 and iOS 16)