### PR TITLE
[Android] Maintain all PNG properties when picking & cropping PNG

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/Compression.java
@@ -64,10 +64,25 @@ class Compression {
             imageDirectory.mkdirs();
         }
 
-        File resizeImageFile = new File(imageDirectory, UUID.randomUUID() + ".jpg");
+        String extension = originalImagePath.substring(originalImagePath.lastIndexOf(".") + 1);
+
+        final String resizeImageFileExtension;
+        final Bitmap.CompressFormat compressFormat;
+        if (extension.equals("png")) {
+            resizeImageFileExtension = ".png";
+            compressFormat = Bitmap.CompressFormat.PNG;
+        } else {
+            resizeImageFileExtension = ".jpg";
+            compressFormat = Bitmap.CompressFormat.JPEG;
+        }
+
+        File resizeImageFile = new File(
+                imageDirectory,
+                UUID.randomUUID() + resizeImageFileExtension
+        );
 
         OutputStream os = new BufferedOutputStream(new FileOutputStream(resizeImageFile));
-        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, os);
+        bitmap.compress(compressFormat, quality, os);
 
         // Don't set unnecessary exif attribute
         if (shouldSetOrientation(originalOrientation)) {

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -53,7 +53,6 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 
 
-
 class PickerModule extends ReactContextBaseJavaModule implements ActivityEventListener {
 
     private static final int IMAGE_PICKER_REQUEST = 61110;
@@ -526,8 +525,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             retriever.setDataSource(path);
 
             return Long.parseLong(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
-        }
-        catch(Exception e) {
+        } catch (Exception e) {
             return -1L;
         }
     }

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -729,7 +729,6 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     private void startCropping(final Activity activity, final Uri uri) {
         UCrop.Options options = new UCrop.Options();
-        options.setCompressionFormat(Bitmap.CompressFormat.JPEG);
         options.setCompressionQuality(100);
         options.setCircleDimmedLayer(cropperCircleOverlay);
         options.setFreeStyleCropEnabled(freeStyleCropEnabled);
@@ -754,15 +753,28 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             configureCropperColors(options);
         }
 
-        UCrop uCrop = UCrop
-                .of(uri, Uri.fromFile(new File(this.getTmpDir(activity), UUID.randomUUID().toString() + ".jpg")))
-                .withOptions(options);
+        try {
+            String originalImagePath = resolveRealPath(activity, uri, false);
+            String extension = originalImagePath.substring(originalImagePath.lastIndexOf("."));
 
-        if (width > 0 && height > 0) {
-            uCrop.withAspectRatio(width, height);
+            if (extension.equals(".png")) {
+                options.setCompressionFormat(Bitmap.CompressFormat.PNG);
+            } else {
+                options.setCompressionFormat(Bitmap.CompressFormat.JPEG);
+            }
+
+            UCrop uCrop = UCrop
+                    .of(uri, Uri.fromFile(new File(this.getTmpDir(activity), UUID.randomUUID().toString() + extension)))
+                    .withOptions(options);
+
+            if (width > 0 && height > 0) {
+                uCrop.withAspectRatio(width, height);
+            }
+
+            uCrop.start(activity);
+        } catch (Exception e) {
+            resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, e.getMessage());
         }
-
-        uCrop.start(activity);
     }
 
     private void imagePickerResult(Activity activity, final int requestCode, final int resultCode, final Intent data) {


### PR DESCRIPTION
Hi all,

Please feel free to suggest/make changes as I am not certain this PR is production ready. 

**Let's make this feature request a thing of the past!!**

I'm using the following configuration:
```ts
const response = await ImageCropPicker.openPicker({
  mediaType: 'photo',
  cropping: true,
  enableRotationGesture: false,
  freeStyleCropEnabled: false,
  cropperActiveWidgetColor: theme.colors.accent,
  cropperChooseColor: '#007AFF', // iOS only
  cropperCancelColor: theme.colors.white, // iOS only
  height: 200,
  width: 200,
  compressImageQuality: 0.8,
  showCropFrame: isAndroid,
});
```

With this config I am able to:
- select a PNG image and maintain its transparency
- select a PNG Image, crop it, and maintain its transparency
- select a JPEG image, optionally crop it (just like before)