### PR TITLE
feat: iOS allow to pick 6 files max at a time

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -57,7 +57,7 @@ RCT_EXPORT_MODULE();
             @"includeExif": @NO,
             @"compressVideo": @YES,
             @"minFiles": @1,
-            @"maxFiles": @5,
+            @"maxFiles": @6,
             @"width": @200,
             @"waitAnimationEnd": @YES,
             @"height": @200,


### PR DESCRIPTION
- needed a feature where in iOS it can pick 6 images at a time max previously it was limit to 5