### PR TITLE
[revert] Fix for openPicker not working when app targets Android 13

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -403,7 +403,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         setConfiguration(options);
         resultCollector.setup(promise, multiple);
 
-        permissionsCheck(activity, promise, Collections.singletonList(Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ? Manifest.permission.WRITE_EXTERNAL_STORAGE : Manifest.permission.READ_MEDIA_IMAGES), new Callable<Void>() {
+        permissionsCheck(activity, promise, Collections.singletonList(Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
             @Override
             public Void call() {
                 initiatePicker(activity);


### PR DESCRIPTION
Revert PR https://github.com/ivpusic/react-native-image-crop-picker/pull/1852

The permission **READ_MEDIA_IMAGES** is not required to open the image picker on Android 13.

> **Note:** If your app only needs to access images, photos, and videos, consider using the [photo picker](https://developer.android.com/about/versions/13/features/photopicker) instead of declaring the **READ_MEDIA_IMAGES** and **READ_MEDIA_VIDEO** permissions.

Source: https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions