### PR TITLE
Removed camera permission on Android since it is not required

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -309,7 +309,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         setConfiguration(options);
         resultCollector.setup(promise, false);
 
-        permissionsCheck(activity, promise, Arrays.asList(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
+        permissionsCheck(activity, promise, Arrays.asList(Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
             @Override
             public Void call() {
                 initiateCamera(activity);


### PR DESCRIPTION
**Manifest.permission.CAMERA** is not required to open the camera and take a picture. So, it could be removed to avoid requesting it to the user.

Also, you need to remove this line from your `app/src/main/AndroidManifest.xml`
```
<uses-permission android:name="android.permission.CAMERA"/>
```