### PR TITLE
fix: make android library error message consistent

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -260,7 +260,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
                             if (grantResult == PackageManager.PERMISSION_DENIED) {
                                 if (permission.equals(Manifest.permission.CAMERA)) {
                                     promise.reject(E_NO_CAMERA_PERMISSION_KEY, E_NO_CAMERA_PERMISSION_MSG);
-                                } else if (permission.equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                                } else if (permission.equals(Manifest.permission.WRITE_EXTERNAL_STORAGE) || permission.equals(Manifest.permission.READ_MEDIA_IMAGES)) {
                                     promise.reject(E_NO_LIBRARY_PERMISSION_KEY, E_NO_LIBRARY_PERMISSION_MSG);
                                 } else {
                                     // should not happen, we fallback on E_NO_LIBRARY_PERMISSION_KEY rejection for minimal consistency


### PR DESCRIPTION
If a user denies access to images, then the error message is a generic `Required permission missing` when it is better to have it more consistent with other media access error message: `User did not grant library permission.`