### PR TITLE
feat(android):RN-0.73 and AGP 8.0 Compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.reactnative.ivpusic.imagepicker"
+    }    
 }
 
 dependencies {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.reactnative.ivpusic.imagepicker">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <queries>
         <intent>


### PR DESCRIPTION
Test Plan:
https://github.com/react-native-community/discussions-and-proposals/issues/671

React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. This will require all the libraries to specify a namespace in their build.gradle file. We added a compatibility layer for libraries that haven't specified a namespace, but please consider updating your libraries nonetheless.
<img width="700" alt="Screenshot 2024-01-20 at 6 01 49 PM" src="https://github.com/ivpusic/react-native-image-crop-picker/assets/15888722/3550b578-0859-4446-ac6c-666578e581fe">
