### PR TITLE
Adds PrivacyInfo.xcprivacy

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>3B52.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Reference
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files#4284009

## Summary
Adds PrivacyInfor.xcprivacy file with reasons
<!-- Simple summary of what was changed. -->

## Motivation
Apple is requiring all packages have a PrivacyInfor.xcprivacy file that declares the privacy info for each package. Starting May 1st, any app that uses a 3rd party application that is missing declarations will be rejected. 
