### PR TITLE
fix(ios): replace `UIGraphicsBeginImageContext` in Compression.m

### DIFF
--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -53,10 +53,10 @@
     }
     CGSize newSize = CGSizeMake(newWidth, newHeight);
     
-    UIGraphicsBeginImageContext(newSize);
-    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
-    UIImage *resizedImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:newSize];
+    UIImage *resizedImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
+    }];
     
     result.width = [NSNumber numberWithFloat:newWidth];
     result.height = [NSNumber numberWithFloat:newHeight];


### PR DESCRIPTION
Fixes #2054

[`UIGraphicsBeginImageContext()`](https://developer.apple.com/documentation/uikit/1623922-uigraphicsbeginimagecontext) is deprecated in iOS 17 and when the width or height is 0, it throws an exception.

The solution is to replace it with [`UIGraphicsImageRenderer`](https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer?language=objc).

See [blog post](https://remarkablemark.org/blog/2024/05/04/how-to-fix-ios-ui-graphics-image-error/).