### PR TITLE
URGENT: Updated RNImageCropPicker.podspec

### DIFF
--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.dependency 'React-Core'
   s.dependency 'React-RCTImage'
-  s.dependency 'TOCropViewController', '~> 2.7.3'
+  s.dependency 'TOCropViewController', '~> 2.7.4'
   s.resource_bundles = {
     'RNImageCropPickerPrivacyInfo' => ['ios/PrivacyInfo.xcprivacy'],
   }


### PR DESCRIPTION
Please approve this PR and release a new version as it includes the crucial fix for the latest version 2.7.4 of TOCropViewController dependency which eliminates the PrivacyInfo.plist file error in the latest RN version >= 0.74.