### PR TITLE
Fixes an issue that would cause the compiler to crash in Xcode 16 beta1

### DIFF
--- a/ios/src/ImageCropPicker.h
+++ b/ios/src/ImageCropPicker.h
@@ -31,7 +31,6 @@
 #elif __has_include("QBImagePickerController.h") // local QBImagePickerController subspec
 #import "QBImagePickerController.h"
 #else
-#import
 #import "QBImagePicker/QBImagePicker.h"
 #endif
 


### PR DESCRIPTION
### Root cause
Incomplete #import statements cause the compiler to crash when checking for dependencies

![image](https://github.com/ivpusic/react-native-image-crop-picker/assets/16702489/0d95dd89-6318-46c6-a34f-b2e27eaab279)

### Solution

Remove this redundant `#import`.