### PR TITLE
fix: Fix image compression on iOS and make it respect to image scale factor

### DIFF
--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -41,25 +41,31 @@
     CGFloat oldWidth = image.size.width;
     CGFloat oldHeight = image.size.height;
     
-    int newWidth = 0;
-    int newHeight = 0;
+    int width = oldWidth;
+    int height = oldHeight;
     
-    if (maxWidth < maxHeight) {
-        newWidth = maxWidth;
-        newHeight = (oldHeight / oldWidth) * newWidth;
-    } else {
-        newHeight = maxHeight;
-        newWidth = (oldWidth / oldHeight) * newHeight;
+    if (width > maxWidth) {
+        height = height * (maxWidth / width);
+        width = maxWidth;
     }
-    CGSize newSize = CGSizeMake(newWidth, newHeight);
+
+    if (height > maxHeight) {
+        width = width * (maxHeight / height);
+        height = maxHeight;
+    }
     
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:newSize];
+    CGSize newSize = CGSizeMake(width, height);
+    
+    UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
+    format.scale = image.scale;
+
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:newSize format:format];
     UIImage *resizedImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
         [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
     }];
     
-    result.width = [NSNumber numberWithFloat:newWidth];
-    result.height = [NSNumber numberWithFloat:newHeight];
+    result.width = [NSNumber numberWithFloat:width];
+    result.height = [NSNumber numberWithFloat:height];
     result.image = resizedImage;
     return result;
 }


### PR DESCRIPTION
#### On iOS the image compression is wrong. It enlarge images after compression.
- Fixed the logic using the Android logic. 
- Also add the scale factor to `UIImage` so that it doesn't make the pixel size increase.