### PR TITLE
Add READ_MEDIA_IMAGES permission for Android 13 (Tiramisu)

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -238,6 +238,10 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             supportedPermissions.remove(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }
 
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU) {
+            supportedPermissions.add(Manifest.permission.READ_MEDIA_IMAGES);
+        }
+
         for (String permission : supportedPermissions) {
             int status = ActivityCompat.checkSelfPermission(activity, permission);
             if (status != PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
## PR Description:

This change adds the READ_MEDIA_IMAGES permission specifically for Android 13 (Tiramisu) due to two key reasons:

Upcoming Android Deadline:
Google has introduced new requirements regarding the usage of the READ_MEDIA_IMAGES permission. As per the latest policy, this permission can only be used if the app is a gallery app or its core functionality involves editing, managing, or maintaining photos. For all other use cases, apps must migrate to the [Android photo picker](https://android-developers.googleblog.com/2023/04/photo-picker-everywhere.html) or use another picker of choice.

Project-Specific Requirement:
The official documentation for the react-native-image-crop-picker project indicates that it's necessary to add the READ_MEDIA_IMAGES permission for Android 13. This ensures compatibility and proper functioning of the library on devices running Android 13. See the documentation for more details [here](https://github.com/ivpusic/react-native-image-crop-picker?tab=readme-ov-file).

This update is critical for compliance with upcoming Android policies and to ensure the app continues to function correctly on Android 13.

## Image and link to the library
https://github.com/ivpusic/react-native-image-crop-picker?tab=readme-ov-file
<img width="926" alt="Screenshot 2024-09-25 at 10 52 48" src="https://github.com/user-attachments/assets/2b475d67-fe2c-4be6-82d8-373b52a884e7">