### PR TITLE
fix: [iOS] Image is being resized up instead of down & Error "User did not grant library permission." in Android 10

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     </queries>
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28" />
+        android:maxSdkVersion="29" />
 
     <application>
 

--- a/ios/src/Compression.m
+++ b/ios/src/Compression.m
@@ -40,27 +40,28 @@
     
     CGFloat oldWidth = image.size.width;
     CGFloat oldHeight = image.size.height;
+
+    CGFloat widthScale = maxWidth / oldWidth;
+    CGFloat heightScale = maxHeight / oldHeight;
+    CGFloat scaleFactor = MIN(widthScale, heightScale);
+
+    CGFloat newWidth = oldWidth * scaleFactor;
+    CGFloat newHeight = oldHeight * scaleFactor;
     
-    int newWidth = 0;
-    int newHeight = 0;
-    
-    if (maxWidth < maxHeight) {
-        newWidth = maxWidth;
-        newHeight = (oldHeight / oldWidth) * newWidth;
-    } else {
-        newHeight = maxHeight;
-        newWidth = (oldWidth / oldHeight) * newHeight;
-    }
     CGSize newSize = CGSizeMake(newWidth, newHeight);
-    
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:newSize];
+
+    UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
+    format.scale = image.scale;
+
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:newSize format:format];
     UIImage *resizedImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
         [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
     }];
     
-    result.width = [NSNumber numberWithFloat:newWidth];
-    result.height = [NSNumber numberWithFloat:newHeight];
+    result.width = @(newWidth);
+    result.height = @(newHeight);
     result.image = resizedImage;
+    
     return result;
 }
 


### PR DESCRIPTION
Fixed: [2100](https://github.com/ivpusic/react-native-image-crop-picker/issues/2100)
Fixed: [2104](https://github.com/ivpusic/react-native-image-crop-picker/issues/2104)
Fixed: [2105](https://github.com/ivpusic/react-native-image-crop-picker/issues/2105)