### PR TITLE
Fix openCamera reported dimensions for portrait photos on Android

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -21,6 +21,7 @@ import android.webkit.MimeTypeMap;
 
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.FileProvider;
+import androidx.exifinterface.media.ExifInterface;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Callback;
@@ -678,6 +679,15 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             throw new Exception("Cannot select remote files");
         }
         BitmapFactory.Options original = validateImage(path);
+        ExifInterface originalExif = new ExifInterface(path);
+        int orientation = originalExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
+        boolean invertDimensions = (
+                orientation == ExifInterface.ORIENTATION_ROTATE_90 ||
+                        orientation == ExifInterface.ORIENTATION_ROTATE_270 ||
+                        orientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+                        orientation == ExifInterface.ORIENTATION_TRANSVERSE
+        );
+
 
         // if compression options are provided image will be compressed. If none options is provided,
         // then original image will be returned
@@ -687,8 +697,8 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         long modificationDate = new File(path).lastModified();
 
         image.putString("path", "file://" + compressedImagePath);
-        image.putInt("width", options.outWidth);
-        image.putInt("height", options.outHeight);
+        image.putInt("width", invertDimensions ? options.outHeight : options.outWidth);
+        image.putInt("height", invertDimensions ? options.outWidth : options.outHeight);
         image.putString("mime", options.outMimeType);
         image.putInt("size", (int) new File(compressedImagePath).length());
         image.putString("modificationDate", String.valueOf(modificationDate));


### PR DESCRIPTION
We're observing width/height being incorrectly reported by the library on Android with portrait photos. This fix, similar to the logic [here](https://github.com/expo/expo/blob/24f5f68e82f527b631c3a19c8a70f06a5ce62968/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/DimensionsExporter.kt#L11-L34), is to swap the reported width/height if the EXIF tag specifies a rotated orientation.

This aligns with the library's behavior on iOS where the width/height are swapped for photos with rotated EXIF.

## Test Plan

Verify that portrait photos (I was using Samsung Galaxy A12) report flipped dimensions, just like the iOS version does.