### PR TITLE
Fix image crop modal failing to show

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -126,7 +126,8 @@ RCT_EXPORT_MODULE();
 
 - (UIViewController*) getRootVC {
     UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
-    while (root.presentedViewController != nil) {
+    while (root.presentedViewController != nil &&
+           !root.presentedViewController.isBeingDismissed) {
         root = root.presentedViewController;
     }
     


### PR DESCRIPTION
Fixes https://github.com/ivpusic/react-native-image-crop-picker/issues/1631

If the controller is being dismissed, we shouldn't be presenting _from_ that controller.

## Test Plan

No longer getting

```
[UIKitCore] Attempt to present <TOCropViewController: 0x104840200> on
<PHPickerViewController: 0x12bf0ece0> (from <PHPickerViewController: 0x12bf0ece0>) whose
view is not in the window hierarchy.
```

when trying to present the cropper right after the Expo image picker.

See the video in https://github.com/bluesky-social/social-app/pull/7194 to show the interaction. Before the fix, we were getting that log and the cropper would not show up.