### PR TITLE
Update ImageCropPicker.m

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -464,7 +464,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 - (void) getVideoAsset:(PHAsset*)forAsset completion:(void (^)(NSDictionary* image))completion {
     PHImageManager *manager = [PHImageManager defaultManager];
     PHVideoRequestOptions *options = [[PHVideoRequestOptions alloc] init];
-    options.version = PHVideoRequestOptionsVersionOriginal;
+    options.version = PHVideoRequestOptionsVersionCurrent;
     options.networkAccessAllowed = YES;
     options.deliveryMode = PHVideoRequestOptionsDeliveryModeHighQualityFormat;
     


### PR DESCRIPTION
Select current selected video instead original one. It happens when user want to select cropped video but could not. Always redirect to original one.

This pull request includes a change to the `ios/src/ImageCropPicker.m` file to update the video request options.

* [`ios/src/ImageCropPicker.m`](diffhunk://#diff-f97babef90914c9e6c6e644667c3ddde067765f32209f394046284094c9345f2L467-R467): Changed the `version` property of `PHVideoRequestOptions` from `PHVideoRequestOptionsVersionOriginal` to `PHVideoRequestOptionsVersionCurrent` in the `getVideoAsset` method.