### PR TITLE
If the "maxFiles" keyword is missing, assign a default value of 5 to align with the documentation.

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -137,7 +137,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         includeExif = options.hasKey("includeExif") && options.getBoolean("includeExif");
         width = options.hasKey("width") ? options.getInt("width") : 0;
         height = options.hasKey("height") ? options.getInt("height") : 0;
-        maxFiles = options.hasKey("maxFiles") ? options.getInt("maxFiles") : 0;
+        maxFiles = options.hasKey("maxFiles") ? options.getInt("maxFiles") : maxFiles;
         cropping = options.hasKey("cropping") && options.getBoolean("cropping");
         cropperActiveWidgetColor = options.hasKey("cropperActiveWidgetColor") ? options.getString("cropperActiveWidgetColor") : null;
         cropperStatusBarColor = options.hasKey("cropperStatusBarColor") ? options.getString("cropperStatusBarColor") : null;

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -104,6 +104,8 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     private int width = 0;
     private int height = 0;
 
+    private int maxFiles = 5;
+
     private Uri mCameraCaptureURI;
     private String mCurrentMediaPath;
     private ResultCollector resultCollector = new ResultCollector();
@@ -135,6 +137,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         includeExif = options.hasKey("includeExif") && options.getBoolean("includeExif");
         width = options.hasKey("width") ? options.getInt("width") : 0;
         height = options.hasKey("height") ? options.getInt("height") : 0;
+        maxFiles = options.hasKey("maxFiles") ? options.getInt("maxFiles") : 0;
         cropping = options.hasKey("cropping") && options.getBoolean("cropping");
         cropperActiveWidgetColor = options.hasKey("cropperActiveWidgetColor") ? options.getString("cropperActiveWidgetColor") : null;
         cropperStatusBarColor = options.hasKey("cropperStatusBarColor") ? options.getString("cropperStatusBarColor") : null;
@@ -381,7 +384,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
             Intent intent;
             if (multiple) {
-                intent = new ActivityResultContracts.PickMultipleVisualMedia().createIntent(activity, builder.build());
+                intent = new ActivityResultContracts.PickMultipleVisualMedia(maxFiles).createIntent(activity, builder.build());
             } else {
                 intent = new ActivityResultContracts.PickVisualMedia().createIntent(activity, builder.build());
             }


### PR DESCRIPTION
Fix the error in the "setConfiguration" function when retrieving "maxFiles" from "options". If the "maxFiles" keyword is missing, assign a default value of 5 to align with the documentation.
![image](https://github.com/user-attachments/assets/fc397169-f69c-4032-bb20-ede8b991c05b)

