### PR TITLE
Fix maxFiles limit for Android image picker

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -371,6 +371,34 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
 
     private void initiatePicker(final Activity activity) {
         try {
+            if (multiple) {
+                initiateModernPicker(activity);
+            } else {
+                initiateClassicPicker(activity);
+            }
+        } catch (Exception e) {
+            resultCollector.notifyProblem(E_FAILED_TO_SHOW_PICKER, e);
+        }
+    }
+
+    private void initiateModernPicker(final Activity activity) {
+        try {
+            String photoPickerAction = "android.provider.action.PICK_IMAGES";
+            
+            Intent intent = new Intent(photoPickerAction);
+            
+            if (maxFiles != Integer.MAX_VALUE) {
+                intent.putExtra("android.provider.extra.PICK_IMAGES_MAX", maxFiles);
+            }
+            
+            activity.startActivityForResult(intent, IMAGE_PICKER_REQUEST);
+        } catch (Exception e) {
+            initiateClassicPicker(activity);
+        }
+    }
+
+    private void initiateClassicPicker(final Activity activity) {
+        try {
             PickVisualMediaRequest.Builder builder = new PickVisualMediaRequest.Builder();
             // Simplified media type handling
             if (mediaType.equals("video")) {


### PR DESCRIPTION
## Description
This PR fixes the `maxFiles` option for Android image picker. Previously, the `maxFiles` option was documented in the README but wasn't properly implemented for Android devices.

## Changes
- Refactored the image picker initialization on Android to use the modern photo picker API
- Added proper implementation of `maxFiles` limit for Android
- Added fallback to the classic picker if the modern picker is not available

## Testing
- Tested on Android 12, 13, and 14
- Verified both single and multiple selection modes work correctly
- Confirmed that the `maxFiles` limit is properly enforced on Android