### PR TITLE
feat(android):Target SDK 35 Compatibility (Edge to Edge enforcement) Ucrop Activity

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -23,8 +23,7 @@
         </provider>
 
         <activity
-            android:name="com.yalantis.ucrop.UCropActivity"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+            android:name="com.yalantis.ucrop.UCropActivity"/>
 
 
         <!-- Prompt Google Play services to install the backported photo picker module -->


### PR DESCRIPTION
After upgrading to target SDK 35, we observed an impact on Android 15 devices, as apps are now edge-to-edge by default if they target Android 15 (API level 35). Image crop picker also impacted with this change as Ucrop activity tool bar distorted and displayed in place of the device status bar and hence user is unable to tap on the icons. Hence removing the style from activity.
Impacted Device : Android 15 & Android 16 with target SDK 35

Before : 
![787cefbf-b1e1-42c7-9e77-380f8935a8f3](https://github.com/user-attachments/assets/3160ab27-feb6-42e9-9ee6-052cd58893b6)

After: 
![Screenshot_20250527_152608](https://github.com/user-attachments/assets/38a2c685-53a9-465f-adbf-6dd89ff81d5e)

