### PR TITLE
Make "Browse" option available in the Android Photo Picker

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -356,22 +356,23 @@ class ImageCropPicker implements ActivityEventListener {
 
     private void initiatePicker(final Activity activity) {
         try {
-            PickVisualMediaRequest.Builder builder = new PickVisualMediaRequest.Builder();
+            String mimeType;
+
             // Simplified media type handling
             if (mediaType.equals("video")) {
-                builder.setMediaType(ActivityResultContracts.PickVisualMedia.VideoOnly.INSTANCE);
+                mimeType = "video/*";
             } else if (mediaType.equals("photo") || cropping) {
                 // Force image-only for cropping
-                builder.setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly.INSTANCE);
+                mimeType = "image/*";
             } else {
-                builder.setMediaType(ActivityResultContracts.PickVisualMedia.ImageAndVideo.INSTANCE);
+                mimeType = "image/*,video/*";
             }
 
             Intent intent;
             if (multiple) {
-                intent = new ActivityResultContracts.PickMultipleVisualMedia(maxFiles).createIntent(activity, builder.build());
+                intent = new ActivityResultContracts.GetMultipleContents().createIntent(activity, mimeType);
             } else {
-                intent = new ActivityResultContracts.PickVisualMedia().createIntent(activity, builder.build());
+                intent = new ActivityResultContracts.GetContent().createIntent(activity, mimeType);
             }
 
             activity.startActivityForResult(intent, IMAGE_PICKER_REQUEST);

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -356,24 +356,20 @@ class ImageCropPicker implements ActivityEventListener {
 
     private void initiatePicker(final Activity activity) {
         try {
-            String mimeType;
+            Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
 
-            // Simplified media type handling
             if (mediaType.equals("video")) {
-                mimeType = "video/*";
+                intent.setType("video/*");
             } else if (mediaType.equals("photo") || cropping) {
                 // Force image-only for cropping
-                mimeType = "image/*";
+                intent.setType("image/*");
             } else {
-                mimeType = "image/*,video/*";
+                intent.setType("image/*");
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"image/*", "video/*"});
             }
 
-            Intent intent;
-            if (multiple) {
-                intent = new ActivityResultContracts.GetMultipleContents().createIntent(activity, mimeType);
-            } else {
-                intent = new ActivityResultContracts.GetContent().createIntent(activity, mimeType);
-            }
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple);
 
             activity.startActivityForResult(intent, IMAGE_PICKER_REQUEST);
         } catch (Exception e) {


### PR DESCRIPTION
Since adding the official Android photo picker (https://github.com/ivpusic/react-native-image-crop-picker/pull/2093), my users have been complaining that they can't choose images from a cloud provider like Google Drive or Google Photos. This change adds the "Browse" option back to the kebab/3 dot menu on the photo picker:
<img width="446" height="267" alt="image" src="https://github.com/user-attachments/assets/bd262d73-fc60-465f-9c57-11a51d7ee17c" />

Pulled from this comment: https://stackoverflow.com/a/77317553