### PR TITLE
Android: Improve error message for cropping failures by including UCrop error details

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -865,7 +865,10 @@ class ImageCropPicker implements ActivityEventListener {
                     resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, ex.getMessage());
                 }
             } else {
-                resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, "Cannot find image data");
+                Throwable cropError = UCrop.getError(data);
+                String errorDetails = (cropError == null) ? "Output URI is null" : "UCrop error: " + cropError.getMessage();
+
+                resultCollector.notifyProblem(E_NO_IMAGE_DATA_FOUND, "Cannot find image data. " + errorDetails);
             }
         } else {
             resultCollector.notifyProblem(E_PICKER_CANCELLED_KEY, E_PICKER_CANCELLED_MSG);


### PR DESCRIPTION
## Description
Improved error handling in the Android crop result handler to provide more specific error messages when image cropping fails.

## Changes
- Enhanced error message in `croppingResult()` method to include specific UCrop error details when available
- Changed generic "Cannot find image data" message to include the actual UCrop error or specify that output URI is null
- Better debugging experience for developers when cropping operations fail

## Before
`Cannot find image data`

## After
`Cannot find image data. UCrop error: [specific error message]`

example:
`Cannot find image data. UCrop error: x must be >= 0`

