### PR TITLE
Android: Update UCrop dependency to native variant (2.2.11-native)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     }
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'com.github.yalantis:ucrop:2.2.11'
+    implementation 'com.github.yalantis:ucrop:2.2.11-native'
     implementation 'androidx.activity:activity:1.10.1'
     implementation "androidx.core:core:1.16.0"
     implementation 'androidx.exifinterface:exifinterface:1.4.1'


### PR DESCRIPTION
## Problem
In version `0.42.0`, `react-native-image-crop-picker` used `com.github.yalantis:ucrop:2.2.6-native`. However, subsequent versions (including the current `0.51.0`) switched to the non-native variant without documented reasoning (or I didn't find anything like that while browsing the repository).

This change introduced a regression where cropping fails when part of the crop area extends beyond the image boundaries, resulting in:
- Error: "Cannot find image data" 
- Underlying UCrop error: "y must be >= 0"
- Complete failure to crop the image

## Solution
Set to the native variant (`2.2.11-native`) which handles boundary conditions gracefully, matching the behavior from version `0.42`.

## Changes
```gradle
- implementation 'com.github.yalantis:ucrop:2.2.11'
+ implementation 'com.github.yalantis:ucrop:2.2.11-native'
```

**Video demonstrations:**
- Without native `com.github.yalantis:ucrop:2.2.11`

https://github.com/user-attachments/assets/78b8143b-5972-455b-bf63-cad02cfbf651

- With native `com.github.yalantis:ucrop:2.2.11-native`


https://github.com/user-attachments/assets/e3169664-2275-4ae7-8430-8d122642e5db