### PR TITLE
Android: Fix maxFiles=1 and multiple=true behavior

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -368,7 +368,7 @@ class ImageCropPicker implements ActivityEventListener {
             }
 
             Intent intent;
-            if (multiple) {
+            if (multiple && maxFiles > 1) {
                 intent = new ActivityResultContracts.PickMultipleVisualMedia(maxFiles).createIntent(activity, builder.build());
             } else {
                 intent = new ActivityResultContracts.PickVisualMedia().createIntent(activity, builder.build());


### PR DESCRIPTION
## Description
Fixed Android behavior when `multiple=true` and `maxFiles=1` to match iOS implementation.

## Problem
Platform inconsistency:
- **iOS**: `multiple=true` with `maxFiles=1` works ✅
- **Android**: Throws "Max items must be higher than 1" ❌

Forces developers to use platform-specific workarounds:
```javascript
multiple={Platform.OS === 'android' ? maxFiles > 1 : true}
```

## Solution
```java
// ImageCropPicker.java

if (multiple && maxFiles > 1) {
   // PickMultipleVisualMedia
} else {
   // PickVisualMedia
}
```

## Before
```javascript
ImagePicker.openPicker({ multiple: true, maxFiles: 1 });
// Android: ❌ Error  
// iOS: ✅ Works
```

## After
```javascript
ImagePicker.openPicker({ multiple: true, maxFiles: 1 });
// Android: ✅ Works
// iOS: ✅ Works (unchanged)
```