### PR TITLE
exclude files from the published bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,12 @@
 .git
-example
+.github
+AwesomeExample
 node_modules
 build
 images
+svg.svg
 
 # android studio
 *.iml
 .idea
 .gradle
-build/


### PR DESCRIPTION
## Description

While working on adding a new metadata information to the React Native Directory, and analysing the results, I have spotted that `react-native-image-crop-picker` published package includes example apps files and GitHub workflows, which increases a bit the final bundle size, see:
* https://www.npmjs.com/package/react-native-image-crop-picker?activeTab=code

To avoid that, I have updated the `.npmignore` file, and added exclusion for the `AwesomeExample` directory, `.github` directory and README asset.

## Test plan

I have run the `npm pack --dry-run` command before and after the changes, and make sure that tests file are no longer a part of the final bundle. 

Results are as follows, before the change:

```
npm notice filename: react-native-image-crop-picker-0.51.0.tgz
npm notice package size: 1.1 MB
npm notice unpacked size: 2.7 MB
npm notice shasum: e7cc8e741372b200ec92a4d9b40ce08a712f125e
npm notice integrity: sha512-HM436RR+Ckdfw[...]DF2ySQ9E5w6qw==
npm notice total files: 160
```

After excluding omittable files:

```
npm notice filename: react-native-image-crop-picker-0.51.0.tgz
npm notice package size: 882.6 kB
npm notice unpacked size: 2.2 MB
npm notice shasum: ed85d07c2a0d95bcfe24419aa25aedb579497c29
npm notice integrity: sha512-kK/9wKZsXoMrw[...]Qs1wYpINymKDA==
npm notice total files: 101
```
