### PR TITLE
fix: return creationDate for videos picked from gallery

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -519,6 +519,48 @@ class ImageCropPicker implements ActivityEventListener {
         }
     }
 
+    // Returns the video's recording date as a Unix-seconds string, or null if unavailable.
+    // Reads METADATA_KEY_DATE from the QuickTime/MP4 container — the canonical recording
+    // timestamp set by the camera. Format mirrors iOS's `creationDate` (seconds since epoch
+    // as a string) so callers can treat both platforms uniformly.
+    private static String getVideoCreationDateSeconds(String path) {
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        try {
+            retriever.setDataSource(path);
+            String dateStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE);
+            if (dateStr == null || dateStr.isEmpty()) {
+                return null;
+            }
+            // QuickTime container date is typically "yyyyMMdd'T'HHmmss.SSS'Z'" (UTC).
+            // Some encoders emit ISO-8601 "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" — try common variants.
+            String[] patterns = {
+                    "yyyyMMdd'T'HHmmss.SSS'Z'",
+                    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+                    "yyyyMMdd'T'HHmmss'Z'"
+            };
+            for (String pattern : patterns) {
+                try {
+                    java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat(pattern, java.util.Locale.US);
+                    sdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+                    java.util.Date parsed = sdf.parse(dateStr);
+                    if (parsed != null) {
+                        return String.valueOf(parsed.getTime() / 1000L);
+                    }
+                } catch (java.text.ParseException ignored) {
+                    // try next pattern
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        } finally {
+            try {
+                retriever.release();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
     private void getVideo(final Activity activity, final String path, final String mime) throws Exception {
         validateVideo(Uri.parse(path));
         final String compressedVideoPath = getTmpDir(activity) + "/" + UUID.randomUUID().toString() + ".mp4";
@@ -530,6 +572,7 @@ class ImageCropPicker implements ActivityEventListener {
                 Bitmap bmp = validateVideo(Uri.fromFile(new File(videoPath)));
                 long modificationDate = new File(videoPath).lastModified();
                 long duration = getVideoDuration(videoPath);
+                String creationDateSeconds = getVideoCreationDateSeconds(videoPath);
 
                 WritableMap video = new WritableNativeMap();
                 video.putInt("width", bmp.getWidth());
@@ -539,6 +582,9 @@ class ImageCropPicker implements ActivityEventListener {
                 video.putInt("duration", (int) duration);
                 video.putString("path", "file://" + videoPath);
                 video.putString("modificationDate", String.valueOf(modificationDate));
+                if (creationDateSeconds != null) {
+                    video.putString("creationDate", creationDateSeconds);
+                }
 
                 resultCollector.notifySuccess(video);
             } catch (Exception e) {

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -472,7 +472,7 @@ class ImageCropPicker implements ActivityEventListener {
 
         String mime = getMimeType(path);
         if (mime != null && mime.startsWith("video/")) {
-            getVideo(activity, path, mime);
+            getVideo(activity, uri, path, mime);
             return null;
         }
 
@@ -488,7 +488,7 @@ class ImageCropPicker implements ActivityEventListener {
 
         String mime = getMimeType(path);
         if (mime != null && mime.startsWith("video/")) {
-            getVideo(activity, path, mime);
+            getVideo(activity, uri, path, mime);
             return;
         }
 
@@ -519,49 +519,35 @@ class ImageCropPicker implements ActivityEventListener {
         }
     }
 
-    // Returns the video's recording date as a Unix-seconds string, or null if unavailable.
-    // Reads METADATA_KEY_DATE from the QuickTime/MP4 container — the canonical recording
-    // timestamp set by the camera. Format mirrors iOS's `creationDate` (seconds since epoch
-    // as a string) so callers can treat both platforms uniformly.
-    private static String getVideoCreationDateSeconds(String path) {
-        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
-        try {
-            retriever.setDataSource(path);
-            String dateStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE);
-            if (dateStr == null || dateStr.isEmpty()) {
+    // MediaStore DATE_TAKEN is the canonical recording timestamp (ms). Preferred over
+    // File.lastModified() (bumped by syncs/copies/edits) for matching iOS PHAsset.creationDate.
+    // Returns Unix seconds as a string to align with the iOS picker's `creationDate` field.
+    private static String getVideoCreationDateSeconds(Activity activity, Uri sourceUri) {
+        if (sourceUri == null) {
+            return null;
+        }
+        try (android.database.Cursor cursor = activity.getContentResolver().query(
+                sourceUri,
+                new String[] { MediaStore.MediaColumns.DATE_TAKEN },
+                null, null, null)) {
+            if (cursor == null || !cursor.moveToFirst()) {
                 return null;
             }
-            // QuickTime container date is typically "yyyyMMdd'T'HHmmss.SSS'Z'" (UTC).
-            // Some encoders emit ISO-8601 "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" — try common variants.
-            String[] patterns = {
-                    "yyyyMMdd'T'HHmmss.SSS'Z'",
-                    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-                    "yyyyMMdd'T'HHmmss'Z'"
-            };
-            for (String pattern : patterns) {
-                try {
-                    java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat(pattern, java.util.Locale.US);
-                    sdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
-                    java.util.Date parsed = sdf.parse(dateStr);
-                    if (parsed != null) {
-                        return String.valueOf(parsed.getTime() / 1000L);
-                    }
-                } catch (java.text.ParseException ignored) {
-                    // try next pattern
-                }
+            int idx = cursor.getColumnIndex(MediaStore.MediaColumns.DATE_TAKEN);
+            if (idx < 0 || cursor.isNull(idx)) {
+                return null;
             }
-            return null;
+            long dateTakenMs = cursor.getLong(idx);
+            if (dateTakenMs <= 0) {
+                return null;
+            }
+            return String.valueOf(dateTakenMs / 1000L);
         } catch (Exception e) {
             return null;
-        } finally {
-            try {
-                retriever.release();
-            } catch (Exception ignored) {
-            }
         }
     }
 
-    private void getVideo(final Activity activity, final String path, final String mime) throws Exception {
+    private void getVideo(final Activity activity, final Uri sourceUri, final String path, final String mime) throws Exception {
         validateVideo(Uri.parse(path));
         final String compressedVideoPath = getTmpDir(activity) + "/" + UUID.randomUUID().toString() + ".mp4";
 
@@ -572,7 +558,7 @@ class ImageCropPicker implements ActivityEventListener {
                 Bitmap bmp = validateVideo(Uri.fromFile(new File(videoPath)));
                 long modificationDate = new File(videoPath).lastModified();
                 long duration = getVideoDuration(videoPath);
-                String creationDateSeconds = getVideoCreationDateSeconds(videoPath);
+                String creationDateSeconds = getVideoCreationDateSeconds(activity, sourceUri);
 
                 WritableMap video = new WritableNativeMap();
                 video.putInt("width", bmp.getWidth());

--- a/ios/src/ImageCropPicker.mm
+++ b/ios/src/ImageCropPicker.mm
@@ -196,6 +196,8 @@ RCT_EXPORT_METHOD(openCamera:(NSDictionary *)options
         [self handleVideo:asset
              withFileName:fileName
       withLocalIdentifier:nil
+         withCreationDate:nil
+     withModificationDate:nil
                completion:^(NSDictionary* video) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (video == nil) {
@@ -420,7 +422,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     });
 }
 
-- (void) handleVideo:(AVAsset*)asset withFileName:(NSString*)fileName withLocalIdentifier:(NSString*)localIdentifier completion:(void (^)(NSDictionary* image))completion {
+- (void) handleVideo:(AVAsset*)asset withFileName:(NSString*)fileName withLocalIdentifier:(NSString*)localIdentifier withCreationDate:(NSDate*)creationDate withModificationDate:(NSDate*)modificationDate completion:(void (^)(NSDictionary* image))completion {
     NSURL *sourceURL = [(AVURLAsset *)asset URL];
     
     // create temp file
@@ -455,8 +457,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                          withDuration:[NSNumber numberWithFloat:milliseconds]
                                              withData:nil
                                              withRect:CGRectNull
-                                     withCreationDate:nil
-                                 withModificationDate:nil
+                                     withCreationDate:creationDate
+                                 withModificationDate:modificationDate
                         ]);
         } else {
             completion(nil);
@@ -479,6 +481,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         [self handleVideo:asset
              withFileName:[forAsset valueForKey:@"filename"]
       withLocalIdentifier:forAsset.localIdentifier
+         withCreationDate:forAsset.creationDate
+     withModificationDate:forAsset.modificationDate
                completion:completion
          ];
     }];


### PR DESCRIPTION
## Summary

This adds video `creationDate` for both iOS and Android videos selected from gallery.

- iOS: forwards `PHAsset.creationDate` / `modificationDate`
- Android: queries `MediaStore.MediaColumns.DATE_TAKEN`.  It already returns `modificationDate`

Output format matches the existing iOS picker convention: Unix seconds as a string (e.g. `"1714932000"`), so `creationDate` is type-stable across platforms and across photo/video selections.

## Steps to reproduce / verify

Pick a video from the gallery via `openPicker({ mediaType: 'video' })`; logged response has `creationDate: null` on both platforms.

**Android before the fix**
<img width="1166" height="78" alt="Screenshot 2026-05-05 at 4 30 45 PM" src="https://github.com/user-attachments/assets/28d88177-d5bf-44bd-9eb7-abe78462968f" />


**Android after the fix**

<img width="1166" height="77" alt="Screenshot 2026-05-05 at 4 35 49 PM" src="https://github.com/user-attachments/assets/43f083e0-b38f-4ba9-8365-d98fe42fdc4b" />


**iOS before the fix**
<img width="1168" height="181" alt="Screenshot 2026-05-05 at 5 17 15 PM" src="https://github.com/user-attachments/assets/ac62b870-e291-48f9-aa88-253e0789bb51" />



**iOS after the fix**

<img width="1170" height="180" alt="Screenshot 2026-05-05 at 5 08 26 PM" src="https://github.com/user-attachments/assets/ef144585-7bc4-4b1b-842b-5afdbbaf34fd" />


## Related

- Builds on the approach in https://github.com/ivpusic/react-native-image-crop-picker/pull/530
- Closes #2079
